### PR TITLE
Adding marble specific fields to item properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datase
 # CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/CMIP/AS-RCEC/catalog.html
 
 testcmip6:
-	python $(IMP_DIR)/CMIP6_UofT/add_CMIP6.py $(STAC_HOST) $(CATALOG)
+	python $(IMP_DIR)/CMIP6_UofT/add_CMIP6.py $(STAC_HOST) $(CATALOG) PAVICS
 
 delcmip6:
 	curl --location --request DELETE '$(STAC_HOST)/collections/CMIP6_UofT'


### PR DESCRIPTION
This PR adds two properties to a STAC item, and in doing so helps describe aspects of the data or the STAC catalog that are useful on the Marble network: `mrbl:is_replica` and `mrbl:host_node`. 

`mrbl:host_node`, specifies the name of the Marble node on which the data is stored. Valid values for this (validity is not checked in this PR) are the values of the keys in the [Marble node registry](https://github.com/DACCS-Climate/Marble-node-registry/blob/current-registry/node_registry.json).

`mrbl:is_replica` is set to `false` in the STAC entry for an item when both the item and the catalog are on `mrbl:host_node`, and is `true` in any replicated STAC entries on any other node in the network (the purpose is very similar to the ESGF `replica` attribute, except on Marble the data is not replicated, only the catalog). 

The purpose of this PR is to get a sense of what others think about this, and to solicit useful feedback. "Implementation" itself is not critical for this PR, ideally, down the line, we would write a "Marble STAC extension" to add these properties and/or other future Marble related properties. Right now, we can just do it in a hack-ish way.