### PR TITLE
help https://github.com/crim-ca/stac-populator/pull/35 resolve conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
     "responses",
     "bump-my-version",
     "jsonschema",
+    "pystac[validation]"
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
https://github.com/crim-ca/stac-populator/pull/35 complaints about `pyproject.toml` conflict: 
```diff
- "jsonschema"
+ "pystac[validation]"
```
Preemptively patch it with both dependencies. 