### PR TITLE
Fixing a bug in thredds loader that limited crawling ability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ DOCKER_TAG := ghcr.io/crim-ca/stac-populator:$(APP_VERSION)
 IMP_DIR := $(APP_NAME)/implementations
 STAC_HOST ?= http://localhost:8880/stac
 # CATALOG = https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/xclim/cmip6/catalog.html
-CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/catalog.html
+# CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/catalog.html
 # CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/CMIP/NOAA-GFDL/catalog.html
 # CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/CMIP/AS-RCEC/catalog.html
+
+# CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/CMIP/NUIST/catalog.html
+CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/CMIP/MIROC/catalog.html
 
 PYESSV_ARCHIVE_DIR ?= ~/.esdoc/pyessv-archive
 PYESSV_ARCHIVE_REF ?= https://github.com/ES-DOC/pyessv-archive

--- a/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
+++ b/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
@@ -58,7 +58,7 @@ def runner(ns: argparse.Namespace) -> Optional[int] | NoReturn:
 
     with Session() as session:
         apply_request_options(session, ns)
-        for collection_path, _, collection_json in STACDirectoryLoader(ns.directory, "collection", ns.prune):
+        for _, collection_path, collection_json in STACDirectoryLoader(ns.directory, "collection", ns.prune):
             collection_dir = os.path.dirname(collection_path)
             loader = STACDirectoryLoader(collection_dir, "item", prune=ns.prune)
             populator = DirectoryPopulator(ns.stac_host, loader, ns.update, collection_json, session=session)

--- a/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
+++ b/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
@@ -1,6 +1,6 @@
 import argparse
 import os.path
-from typing import NoReturn, Optional, MutableMapping, Any
+from typing import Any, MutableMapping, NoReturn, Optional
 
 from requests.sessions import Session
 
@@ -45,8 +45,9 @@ def make_parser() -> argparse.ArgumentParser:
     parser.add_argument("directory", type=str, help="Path to a directory structure with STAC Collections and Items.")
     parser.add_argument("--update", action="store_true", help="Update collection and its items.")
     parser.add_argument(
-        "--prune", action="store_true",
-        help="Limit search of STAC Collections only to first top-most matches in the crawled directory structure."
+        "--prune",
+        action="store_true",
+        help="Limit search of STAC Collections only to first top-most matches in the crawled directory structure.",
     )
     add_request_options(parser)
     return parser
@@ -57,7 +58,7 @@ def runner(ns: argparse.Namespace) -> Optional[int] | NoReturn:
 
     with Session() as session:
         apply_request_options(session, ns)
-        for collection_path, collection_json in STACDirectoryLoader(ns.directory, "collection", ns.prune):
+        for collection_path, _, collection_json in STACDirectoryLoader(ns.directory, "collection", ns.prune):
             collection_dir = os.path.dirname(collection_path)
             loader = STACDirectoryLoader(collection_dir, "item", prune=ns.prune)
             populator = DirectoryPopulator(ns.stac_host, loader, ns.update, collection_json, session=session)

--- a/STACpopulator/input.py
+++ b/STACpopulator/input.py
@@ -137,7 +137,11 @@ class THREDDSLoader(GenericLoader):
         self.catalog_head = self.catalog
 
     def __iter__(self) -> Iterator[Tuple[str, str, MutableMapping[str, Any]]]:
-        """Return a generator walking a THREDDS data catalog for datasets."""
+        """Return a generator walking a THREDDS data catalog for datasets.
+
+        :yield: Returns three quantities: name of the item, location of the item, and its attributes
+        :rtype: Iterator[Tuple[str, str, MutableMapping[str, Any]]]
+        """
 
         if self._depth > self._max_depth:
             return
@@ -198,7 +202,13 @@ class STACDirectoryLoader(GenericLoader):
         self._collection_mode = mode == "collection"
         self._collection_name = "collection.json"
 
-    def __iter__(self) -> Iterator[Tuple[str, MutableMapping[str, Any]]]:
+    def __iter__(self) -> Iterator[Tuple[str, str, MutableMapping[str, Any]]]:
+        """Return a generator that walks through a directory structure looking for sTAC Collections or Items.
+
+        :yield: Returns three quantities: name of the item, location of the item, and its attributes
+        :rtype: Iterator[Tuple[str, str, MutableMapping[str, Any]]]
+        """
+
         is_root = True
         for root, dirs, files in self.iter:
             # since there can ever be only one 'collection' file name in a same directory
@@ -207,7 +217,7 @@ class STACDirectoryLoader(GenericLoader):
                 if self.prune:  # stop recursive search if requested
                     del dirs[:]
                 col_path = os.path.join(root, self._collection_name)
-                yield col_path, "", self._load_json(col_path)
+                yield self._collection_name, col_path, self._load_json(col_path)
             # if a collection is found deeper when not expected for items parsing
             # drop the nested directories to avoid over-crawling nested collections
             elif not self._collection_mode and not is_root and self._collection_name in files:
@@ -217,7 +227,7 @@ class STACDirectoryLoader(GenericLoader):
             for name in files:
                 if not self._collection_mode and self._is_item(name):
                     item_path = os.path.join(root, name)
-                    yield item_path, "", self._load_json(item_path)
+                    yield self._collection_name, item_path, self._load_json(item_path)
 
     def _is_item(self, path: Union[os.PathLike[str], str]) -> bool:
         name = os.path.split(path)[-1]

--- a/STACpopulator/input.py
+++ b/STACpopulator/input.py
@@ -146,7 +146,6 @@ class THREDDSLoader(GenericLoader):
             for item_name, ds in self.catalog_head.datasets.items():
                 attrs = self.extract_metadata(ds)
                 yield item_name, ds.url_path, attrs
-                # yield item_name, ds.url_path, []
 
         for name, ref in self.catalog_head.catalog_refs.items():
             self.catalog_head = ref.follow()
@@ -208,7 +207,7 @@ class STACDirectoryLoader(GenericLoader):
                 if self.prune:  # stop recursive search if requested
                     del dirs[:]
                 col_path = os.path.join(root, self._collection_name)
-                yield col_path, self._load_json(col_path)
+                yield col_path, "", self._load_json(col_path)
             # if a collection is found deeper when not expected for items parsing
             # drop the nested directories to avoid over-crawling nested collections
             elif not self._collection_mode and not is_root and self._collection_name in files:
@@ -218,7 +217,7 @@ class STACDirectoryLoader(GenericLoader):
             for name in files:
                 if not self._collection_mode and self._is_item(name):
                     item_path = os.path.join(root, name)
-                    yield item_path, self._load_json(item_path)
+                    yield item_path, "", self._load_json(item_path)
 
     def _is_item(self, path: Union[os.PathLike[str], str]) -> bool:
         name = os.path.split(path)[-1]

--- a/STACpopulator/populator_base.py
+++ b/STACpopulator/populator_base.py
@@ -17,7 +17,6 @@ from STACpopulator.input import GenericLoader
 from STACpopulator.models import AnyGeometry
 from STACpopulator.stac_utils import get_logger, load_config, url_validate
 
-
 LOGGER = get_logger(__name__)
 
 
@@ -144,9 +143,12 @@ class STACpopulatorBase(ABC):
         post_stac_collection(self.stac_host, collection_data, self.update, session=self._session)
 
     def ingest(self) -> None:
+        counter = 0
         LOGGER.info("Data ingestion")
-        for item_name, item_data in self._ingest_pipeline:
-            LOGGER.info(f"Creating STAC representation for {item_name}")
+        for item_name, item_loc, item_data in self._ingest_pipeline:
+            LOGGER.info(f"New data item: {item_name}")
+            if item_loc:
+                LOGGER.info(f"Data location: {item_loc}")
             stac_item = self.create_stac_item(item_name, item_data)
             if stac_item:
                 post_stac_item(
@@ -157,3 +159,5 @@ class STACpopulatorBase(ABC):
                     update=self.update,
                     session=self._session,
                 )
+                counter += 1
+                LOGGER.info(f"Processed {counter} data items")

--- a/STACpopulator/populator_base.py
+++ b/STACpopulator/populator_base.py
@@ -147,8 +147,7 @@ class STACpopulatorBase(ABC):
         LOGGER.info("Data ingestion")
         for item_name, item_loc, item_data in self._ingest_pipeline:
             LOGGER.info(f"New data item: {item_name}")
-            if item_loc:
-                LOGGER.info(f"Data location: {item_loc}")
+            LOGGER.info(f"Data location: {item_loc}")
             stac_item = self.create_stac_item(item_name, item_data)
             if stac_item:
                 post_stac_item(
@@ -161,3 +160,5 @@ class STACpopulatorBase(ABC):
                 )
                 counter += 1
                 LOGGER.info(f"Processed {counter} data items")
+            else:
+                LOGGER.error("Failed to create STAC representation")


### PR DESCRIPTION
A subtle bug was limiting the number of files that could be successfully crawled by the crawler before the crawler abruptly stopped (without error). Investigation released that this had to do with the "depth" variable in the `THREDDSLoader` class, that was [originally](https://github.com/crim-ca/stac-ingest/blob/e4cc2a66fee4b86ec238f139135d78215ec91ea4/stac_ingest/utils/tds.py) put in place to limit the depth to which the crawler will crawl. This original logic was largely retained, however, it turns out, there was an error in the logic which only showed up while crawling several deeply-nested data structures like the datasets in the [UofT CMIP6 data catalog](https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/catalog.html). Essentially, the depth variable was always linearly decreasing and when it became 0, the crawler stopped working. This PR fixes that issue. 