### PR TITLE
Adding feature to intercept errors and save information to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build
 
 ## Logs
 *.jsonl
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ reports
 STACpopulator.egg-info/
 build
 *.pyc
+
+## Logs
+*.jsonl

--- a/STACpopulator/api_requests.py
+++ b/STACpopulator/api_requests.py
@@ -73,7 +73,7 @@ def post_stac_item(
     json_data: dict[str, dict],
     update: Optional[bool] = True,
     session: Optional[Session] = None,
-) -> Union[None, str]:
+) -> None:
     """Post a STAC item to the host server.
 
     :param stac_host: address of the STAC host
@@ -99,12 +99,10 @@ def post_stac_item(
         if update:
             LOGGER.info(f"Item {item_id} already exists. Updating.")
             r = session.put(os.path.join(stac_host, f"collections/{collection_id}/items/{item_id}"), json=json_data)
-            return f"Requests: {r.reason}"
-            # r.raise_for_status()
+            # return f"Requests: {r.reason}"
+            r.raise_for_status()
         else:
             LOGGER.warn(f"Item {item_id} already exists.")
     else:
-        return f"Requests: {r.reason}"
-        # r.raise_for_status()
-
-    return None
+        # return f"Requests: {r.reason}"
+        r.raise_for_status()

--- a/STACpopulator/api_requests.py
+++ b/STACpopulator/api_requests.py
@@ -99,10 +99,8 @@ def post_stac_item(
         if update:
             LOGGER.info(f"Item {item_id} already exists. Updating.")
             r = session.put(os.path.join(stac_host, f"collections/{collection_id}/items/{item_id}"), json=json_data)
-            # return f"Requests: {r.reason}"
             r.raise_for_status()
         else:
             LOGGER.warn(f"Item {item_id} already exists.")
     else:
-        # return f"Requests: {r.reason}"
         r.raise_for_status()

--- a/STACpopulator/api_requests.py
+++ b/STACpopulator/api_requests.py
@@ -1,10 +1,10 @@
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import requests
-from requests import Session
 from colorlog import ColoredFormatter
+from requests import Session
 
 LOGGER = logging.getLogger(__name__)
 LOGFORMAT = "  %(log_color)s%(levelname)s:%(reset)s %(blue)s[%(name)-30s]%(reset)s %(message)s"
@@ -81,7 +81,7 @@ def post_stac_item(
     json_data: dict[str, dict],
     update: Optional[bool] = True,
     session: Optional[Session] = None,
-) -> None:
+) -> Union[None, str]:
     """Post a STAC item to the host server.
 
     :param stac_host: address of the STAC host
@@ -107,8 +107,12 @@ def post_stac_item(
         if update:
             LOGGER.info(f"Item {item_id} already exists. Updating.")
             r = session.put(os.path.join(stac_host, f"collections/{collection_id}/items/{item_id}"), json=json_data)
-            r.raise_for_status()
+            return f"Requests: {r.reason}"
+            # r.raise_for_status()
         else:
-            LOGGER.info(f"Item {item_id} already exists.")
+            LOGGER.warn(f"Item {item_id} already exists.")
     else:
-        r.raise_for_status()
+        return f"Requests: {r.reason}"
+        # r.raise_for_status()
+
+    return None

--- a/STACpopulator/api_requests.py
+++ b/STACpopulator/api_requests.py
@@ -3,17 +3,9 @@ import os
 from typing import Any, Optional, Union
 
 import requests
-from colorlog import ColoredFormatter
 from requests import Session
 
 LOGGER = logging.getLogger(__name__)
-LOGFORMAT = "  %(log_color)s%(levelname)s:%(reset)s %(blue)s[%(name)-30s]%(reset)s %(message)s"
-formatter = ColoredFormatter(LOGFORMAT)
-stream = logging.StreamHandler()
-stream.setFormatter(formatter)
-LOGGER.addHandler(stream)
-LOGGER.setLevel(logging.INFO)
-LOGGER.propagate = False
 
 
 def stac_host_reachable(url: str, session: Optional[Session] = None) -> bool:

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -123,6 +123,7 @@ def make_main_parser() -> argparse.ArgumentParser:
     )
 
     # add more commands as needed...
+    parser.add_argument("--debug", action="store_true", help="Set logger level to debug")
 
     return parser
 

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -1,16 +1,19 @@
 import argparse
 import glob
 import importlib
+import logging
 import os
 import sys
+from datetime import datetime
+from http import cookiejar
 from typing import Callable, Optional
 
 import requests
-from http import cookiejar
 from requests.auth import AuthBase, HTTPBasicAuth, HTTPDigestAuth, HTTPProxyAuth
 from requests.sessions import Session
 
 from STACpopulator import __version__
+from STACpopulator.logging import setup_logging
 
 POPULATORS = {}
 
@@ -54,19 +57,24 @@ def add_request_options(parser: argparse.ArgumentParser) -> None:
     Adds arguments to a parser to allow update of a request session definition used across a populator procedure.
     """
     parser.add_argument(
-        "--no-verify", "--no-ssl", "--no-ssl-verify", dest="verify", action="store_false",
-        help="Disable SSL verification (not recommended unless for development/test servers)."
+        "--no-verify",
+        "--no-ssl",
+        "--no-ssl-verify",
+        dest="verify",
+        action="store_false",
+        help="Disable SSL verification (not recommended unless for development/test servers).",
+    )
+    parser.add_argument("--cert", type=argparse.FileType(), required=False, help="Path to a certificate file to use.")
+    parser.add_argument(
+        "--auth-handler",
+        choices=["basic", "digest", "bearer", "proxy", "cookie"],
+        required=False,
+        help="Authentication strategy to employ for the requests session.",
     )
     parser.add_argument(
-        "--cert", type=argparse.FileType(), required=False, help="Path to a certificate file to use."
-    )
-    parser.add_argument(
-        "--auth-handler", choices=["basic", "digest", "bearer", "proxy", "cookie"], required=False,
-        help="Authentication strategy to employ for the requests session."
-    )
-    parser.add_argument(
-        "--auth-identity", required=False,
-        help="Bearer token, cookie-jar file or proxy/digest/basic username:password for selected authorization handler."
+        "--auth-identity",
+        required=False,
+        help="Bearer token, cookie-jar file or proxy/digest/basic username:password for selected authorization handler.",
     )
 
 
@@ -93,16 +101,25 @@ def apply_request_options(session: Session, namespace: argparse.Namespace) -> No
 
 def make_main_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="stac-populator", description="STACpopulator operations.")
-    parser.add_argument("--version", "-V", action="version", version=f"%(prog)s {__version__}",
-                        help="prints the version of the library and exits")
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="version",
+        version=f"%(prog)s {__version__}",
+        help="prints the version of the library and exits",
+    )
     commands = parser.add_subparsers(title="command", dest="command", description="STAC populator command to execute.")
 
     run_cmd_parser = make_run_command_parser(parser.prog)
     commands.add_parser(
         "run",
-        prog=f"{parser.prog} {run_cmd_parser.prog}", parents=[run_cmd_parser],
-        formatter_class=run_cmd_parser.formatter_class, usage=run_cmd_parser.usage,
-        add_help=False, help=run_cmd_parser.description, description=run_cmd_parser.description
+        prog=f"{parser.prog} {run_cmd_parser.prog}",
+        parents=[run_cmd_parser],
+        formatter_class=run_cmd_parser.formatter_class,
+        usage=run_cmd_parser.usage,
+        add_help=False,
+        help=run_cmd_parser.description,
+        description=run_cmd_parser.description,
     )
 
     # add more commands as needed...
@@ -142,9 +159,12 @@ def make_run_command_parser(parent) -> argparse.ArgumentParser:
             populator_prog = f"{parent} {parser.prog} {populator_name}"
             subparsers.add_parser(
                 populator_name,
-                prog=populator_prog, parents=[populator_parser], formatter_class=populator_parser.formatter_class,
+                prog=populator_prog,
+                parents=[populator_parser],
+                formatter_class=populator_parser.formatter_class,
                 add_help=False,  # add help disabled otherwise conflicts with this main populator help
-                help=populator_parser.description, description=populator_parser.description,
+                help=populator_parser.description,
+                description=populator_parser.description,
                 usage=populator_parser.usage,
             )
             POPULATORS[populator_name] = {
@@ -168,6 +188,12 @@ def main(*args: str) -> Optional[int]:
     result = None
     if populator_cmd == "run":
         populator_name = params.pop("populator")
+
+        # Setup the application logger:
+        fname = f"{populator_name}_log_{datetime.utcnow().isoformat() + 'Z'}.jsonl"
+        log_level = logging.DEBUG if ns.debug else logging.INFO
+        setup_logging(fname, log_level)
+
         if not populator_name:
             parser.print_help()
             return 0

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 import os
 from typing import Any, MutableMapping, NoReturn, Optional, Union
 
@@ -13,9 +14,8 @@ from STACpopulator.extensions.thredds import THREDDSExtension, THREDDSHelper
 from STACpopulator.input import ErrorLoader, GenericLoader, THREDDSLoader
 from STACpopulator.models import GeoJSONPolygon
 from STACpopulator.populator_base import STACpopulatorBase
-from STACpopulator.stac_utils import get_logger
 
-LOGGER = get_logger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 class CMIP6populator(STACpopulatorBase):

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -29,6 +29,7 @@ class CMIP6populator(STACpopulatorBase):
         update: Optional[bool] = False,
         session: Optional[Session] = None,
         config_file: Optional[Union[os.PathLike[str], str]] = None,
+        log_debug: Optional[bool] = False,
     ) -> None:
         """Constructor
 
@@ -37,11 +38,7 @@ class CMIP6populator(STACpopulatorBase):
         :param data_loader: loader to iterate over ingestion data.
         """
         super().__init__(
-            stac_host,
-            data_loader,
-            update=update,
-            session=session,
-            config_file=config_file,
+            stac_host, data_loader, update=update, session=session, config_file=config_file, log_debug=log_debug
         )
 
     def create_stac_item(
@@ -101,6 +98,7 @@ def make_parser() -> argparse.ArgumentParser:
             "By default, uses the adjacent configuration to the implementation class."
         ),
     )
+    parser.add_argument("--debug", action="store_true", help="Set logger level to debug")
     add_request_options(parser)
     return parser
 
@@ -116,7 +114,9 @@ def runner(ns: argparse.Namespace) -> Optional[int] | NoReturn:
             # To be implemented
             data_loader = ErrorLoader()
 
-        c = CMIP6populator(ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config)
+        c = CMIP6populator(
+            ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config, log_debug=ns.debug
+        )
         c.ingest()
 
 

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -46,7 +46,7 @@ class CMIP6populator(STACpopulatorBase):
 
     def create_stac_item(
         self, item_name: str, item_data: MutableMapping[str, Any]
-    ) -> Union[(int, str), MutableMapping[str, Any]]:
+    ) -> Union[tuple[int, str], MutableMapping[str, Any]]:
         """Creates the STAC item.
 
         :param item_name: name of the STAC item. Interpretation of name is left to the input loader implementation

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -98,7 +98,6 @@ def make_parser() -> argparse.ArgumentParser:
             "By default, uses the adjacent configuration to the implementation class."
         ),
     )
-    parser.add_argument("--debug", action="store_true", help="Set logger level to debug")
     add_request_options(parser)
     return parser
 

--- a/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
+++ b/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os.path
 from typing import Any, MutableMapping, NoReturn, Optional
 
@@ -8,9 +9,8 @@ from STACpopulator.cli import add_request_options, apply_request_options
 from STACpopulator.input import STACDirectoryLoader
 from STACpopulator.models import GeoJSONPolygon
 from STACpopulator.populator_base import STACpopulatorBase
-from STACpopulator.stac_utils import get_logger
 
-LOGGER = get_logger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 class DirectoryPopulator(STACpopulatorBase):

--- a/STACpopulator/input.py
+++ b/STACpopulator/input.py
@@ -8,20 +8,12 @@ import pystac
 import requests
 import siphon
 import xncml
-from colorlog import ColoredFormatter
 from requests.sessions import Session
 from siphon.catalog import TDSCatalog, session_manager
 
 from STACpopulator.stac_utils import numpy_to_python_datatypes, url_validate
 
 LOGGER = logging.getLogger(__name__)
-LOGFORMAT = "  %(log_color)s%(levelname)s:%(reset)s %(blue)s[%(name)-30s]%(reset)s %(message)s"
-formatter = ColoredFormatter(LOGFORMAT)
-stream = logging.StreamHandler()
-stream.setFormatter(formatter)
-LOGGER.addHandler(stream)
-LOGGER.setLevel(logging.INFO)
-LOGGER.propagate = False
 
 
 class GenericLoader(ABC):

--- a/STACpopulator/input.py
+++ b/STACpopulator/input.py
@@ -141,7 +141,9 @@ class THREDDSLoader(GenericLoader):
         if self.catalog_head.datasets.items():
             for item_name, ds in self.catalog_head.datasets.items():
                 attrs = self.extract_metadata(ds)
-                yield item_name, ds.url_path, attrs
+                filename = ds.url_path[ds.url_path.rfind("/") :]
+                url = self.catalog_head.catalog_url[: self.catalog_head.catalog_url.rfind("/")] + filename
+                yield item_name, url, attrs
 
         for name, ref in self.catalog_head.catalog_refs.items():
             self.catalog_head = ref.follow()

--- a/STACpopulator/logging.py
+++ b/STACpopulator/logging.py
@@ -29,7 +29,7 @@ LOG_RECORD_BUILTIN_ATTRS = {
 }
 
 
-def setup_logging(logfname: str, log_level: str) -> None:
+def setup_logging(logfname: str, log_level: int) -> None:
     """Setup the logger for the app.
 
     :param logfname: name of the file to which to write log outputs
@@ -40,7 +40,7 @@ def setup_logging(logfname: str, log_level: str) -> None:
     config = logconfig
     config["handlers"]["file"]["filename"] = logfname
     for handler in config["handlers"]:
-        config["handlers"][handler]["level"] = log_level
+        config["handlers"][handler]["level"] = logging.getLevelName(log_level)
     logging.config.dictConfig(config)
 
 
@@ -97,7 +97,7 @@ logconfig = {
             "datefmt": "%Y-%m-%dT%H:%M:%S%z",
         },
         "json": {
-            "()": "STACpopulator.logging.JSONLogFormatter",
+            "()": f"{JSONLogFormatter.__module__}.{JSONLogFormatter.__name__}",
             "fmt_keys": {
                 "level": "levelname",
                 "message": "message",

--- a/STACpopulator/logging.py
+++ b/STACpopulator/logging.py
@@ -29,6 +29,21 @@ LOG_RECORD_BUILTIN_ATTRS = {
 }
 
 
+def setup_logging(logfname: str, log_level: str) -> None:
+    """Setup the logger for the app.
+
+    :param logfname: name of the file to which to write log outputs
+    :type logfname: str
+    :param log_level: base logging level (e.g. "INFO")
+    :type log_level: str
+    """
+    config = logconfig
+    config["handlers"]["file"]["filename"] = logfname
+    for handler in config["handlers"]:
+        config["handlers"][handler]["level"] = log_level
+    logging.config.dictConfig(config)
+
+
 class JSONLogFormatter(logging.Formatter):
     # From: https://github.com/mCodingLLC/VideosSampleCode/tree/master/videos/135_modern_logging
     def __init__(

--- a/STACpopulator/logging.py
+++ b/STACpopulator/logging.py
@@ -1,0 +1,113 @@
+import datetime as dt
+import json
+import logging
+
+LOG_RECORD_BUILTIN_ATTRS = {
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "module",
+    "msecs",
+    "message",
+    "msg",
+    "name",
+    "pathname",
+    "process",
+    "processName",
+    "relativeCreated",
+    "stack_info",
+    "thread",
+    "threadName",
+    "taskName",
+}
+
+
+class JSONLogFormatter(logging.Formatter):
+    # From: https://github.com/mCodingLLC/VideosSampleCode/tree/master/videos/135_modern_logging
+    def __init__(
+        self,
+        *,
+        fmt_keys: dict[str, str] | None = None,
+    ):
+        super().__init__()
+        self.fmt_keys = fmt_keys if fmt_keys is not None else {}
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = self._prepare_log_dict(record)
+        return json.dumps(message, default=str)
+
+    def _prepare_log_dict(self, record: logging.LogRecord):
+        always_fields = {
+            "message": record.getMessage(),
+            "timestamp": dt.datetime.fromtimestamp(record.created, tz=dt.timezone.utc).isoformat(),
+        }
+        if record.exc_info is not None:
+            always_fields["exc_info"] = self.formatException(record.exc_info)
+
+        if record.stack_info is not None:
+            always_fields["stack_info"] = self.formatStack(record.stack_info)
+
+        message = {
+            key: msg_val if (msg_val := always_fields.pop(val, None)) is not None else getattr(record, val)
+            for key, val in self.fmt_keys.items()
+        }
+        message.update(always_fields)
+
+        for key, val in record.__dict__.items():
+            if key not in LOG_RECORD_BUILTIN_ATTRS:
+                message[key] = val
+
+        return message
+
+
+class NonErrorFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool | logging.LogRecord:
+        return record.levelno <= logging.INFO
+
+
+logconfig = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "simple": {
+            "()": "colorlog.ColoredFormatter",
+            "format": "  %(log_color)s%(levelname)s:%(reset)s %(blue)s[%(name)-30s]%(reset)s %(message)s",
+            "datefmt": "%Y-%m-%dT%H:%M:%S%z",
+        },
+        "json": {
+            "()": "STACpopulator.logging.JSONLogFormatter",
+            "fmt_keys": {
+                "level": "levelname",
+                "message": "message",
+                "timestamp": "timestamp",
+                "logger": "name",
+                "module": "module",
+                "function": "funcName",
+                "line": "lineno",
+                "thread_name": "threadName",
+            },
+        },
+    },
+    "handlers": {
+        "stderr": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+            "formatter": "simple",
+            "stream": "ext://sys.stderr",
+        },
+        "file": {
+            "class": "logging.FileHandler",
+            "level": "INFO",
+            "formatter": "json",
+            "filename": "__added_dynamically__",
+        },
+    },
+    "loggers": {"root": {"level": "DEBUG", "handlers": ["stderr", "file"]}},
+}

--- a/STACpopulator/populator_base.py
+++ b/STACpopulator/populator_base.py
@@ -16,7 +16,6 @@ from STACpopulator.api_requests import (
     stac_host_reachable,
 )
 from STACpopulator.input import GenericLoader
-from STACpopulator.logging import setup_logging
 from STACpopulator.models import AnyGeometry
 from STACpopulator.stac_utils import load_config, url_validate
 
@@ -43,7 +42,6 @@ class STACpopulatorBase(ABC):
         """
 
         super().__init__()
-        self.configure_app_logging(log_debug)
         self._collection_config_path = config_file
         self._collection_info: MutableMapping[str, Any] = None
         self._session = session
@@ -146,14 +144,6 @@ class STACpopulatorBase(ABC):
 
     def publish_stac_collection(self, collection_data: dict[str, Any]) -> None:
         post_stac_collection(self.stac_host, collection_data, self.update, session=self._session)
-
-    def configure_app_logging(self, log_debug) -> None:
-        """Configure the logger for the App."""
-        # generating the log file name
-        implementation_name = type(self).__name__
-        fname = f"{implementation_name}_log_{datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')}.jsonl"
-        log_level = "DEBUG" if log_debug else "INFO"
-        setup_logging(fname, log_level)
 
     def ingest(self) -> None:
         counter = 0

--- a/STACpopulator/populator_base.py
+++ b/STACpopulator/populator_base.py
@@ -29,6 +29,7 @@ class STACpopulatorBase(ABC):
         update: Optional[bool] = False,
         session: Optional[Session] = None,
         config_file: Optional[Union[os.PathLike[str], str]] = "collection_config.yml",
+        log_debug: Optional[bool] = False,
     ) -> None:
         """Constructor
 
@@ -40,7 +41,7 @@ class STACpopulatorBase(ABC):
         """
 
         super().__init__()
-        self.configure_app_logging()
+        self.configure_app_logging(log_debug)
         self._collection_config_path = config_file
         self._collection_info: MutableMapping[str, Any] = None
         self._session = session
@@ -144,12 +145,13 @@ class STACpopulatorBase(ABC):
     def publish_stac_collection(self, collection_data: dict[str, Any]) -> None:
         post_stac_collection(self.stac_host, collection_data, self.update, session=self._session)
 
-    def configure_app_logging(self) -> None:
+    def configure_app_logging(self, log_debug) -> None:
         """Configure the logger for the App."""
         # generating the log file name
         implementation_name = type(self).__name__
         fname = f"{implementation_name}_log_{datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')}.jsonl"
-        setup_logging(fname)
+        log_level = "DEBUG" if log_debug else "INFO"
+        setup_logging(fname, log_level)
 
     def ingest(self) -> None:
         counter = 0

--- a/STACpopulator/populator_base.py
+++ b/STACpopulator/populator_base.py
@@ -15,8 +15,9 @@ from STACpopulator.api_requests import (
     stac_host_reachable,
 )
 from STACpopulator.input import GenericLoader
+from STACpopulator.logging import setup_logging
 from STACpopulator.models import AnyGeometry
-from STACpopulator.stac_utils import load_config, setup_logging, url_validate
+from STACpopulator.stac_utils import load_config, url_validate
 
 LOGGER = logging.getLogger(__name__)
 

--- a/STACpopulator/stac_utils.py
+++ b/STACpopulator/stac_utils.py
@@ -11,14 +11,18 @@ import yaml
 from STACpopulator.logging import logconfig
 
 
-def setup_logging(logfname: str) -> None:
+def setup_logging(logfname: str, log_level: str) -> None:
     """Setup the logger for the app.
 
     :param logfname: name of the file to which to write log outputs
     :type logfname: str
+    :param log_level: base logging level (e.g. "INFO")
+    :type log_level: str
     """
     config = logconfig
     config["handlers"]["file"]["filename"] = logfname
+    for handler in config["handlers"]:
+        config["handlers"][handler]["level"] = log_level
     logging.config.dictConfig(config)
 
 

--- a/STACpopulator/stac_utils.py
+++ b/STACpopulator/stac_utils.py
@@ -7,24 +7,22 @@ from typing import Any, Literal, MutableMapping, Type, Union
 import numpy as np
 import pystac
 import yaml
-from colorlog import ColoredFormatter
+
+from STACpopulator.logging import logconfig
 
 
-def get_logger(
-    name: str,
-    log_fmt: str = "  %(log_color)s%(levelname)s:%(reset)s %(blue)s[%(name)-30s]%(reset)s %(message)s",
-) -> logging.Logger:
-    logger = logging.getLogger(name)
-    formatter = ColoredFormatter(log_fmt)
-    stream = logging.StreamHandler()
-    stream.setFormatter(formatter)
-    logger.addHandler(stream)
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
-    return logger
+def setup_logging(logfname: str) -> None:
+    """Setup the logger for the app.
+
+    :param logfname: name of the file to which to write log outputs
+    :type logfname: str
+    """
+    config = logconfig
+    config["handlers"]["file"]["filename"] = logfname
+    logging.config.dictConfig(config)
 
 
-LOGGER = get_logger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def url_validate(target: str) -> bool:

--- a/STACpopulator/stac_utils.py
+++ b/STACpopulator/stac_utils.py
@@ -8,24 +8,6 @@ import numpy as np
 import pystac
 import yaml
 
-from STACpopulator.logging import logconfig
-
-
-def setup_logging(logfname: str, log_level: str) -> None:
-    """Setup the logger for the app.
-
-    :param logfname: name of the file to which to write log outputs
-    :type logfname: str
-    :param log_level: base logging level (e.g. "INFO")
-    :type log_level: str
-    """
-    config = logconfig
-    config["handlers"]["file"]["filename"] = logfname
-    for handler in config["handlers"]:
-        config["handlers"][handler]["level"] = log_level
-    logging.config.dictConfig(config)
-
-
 LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Adding feature to intercept errors encountered while (i) generating STAC items, (ii) posting STAC items to the server. Information about the dataset and the error it encountered are saved to separate log files. An example log file from a run of the stac-populator is included below.

[stac-populator_CMIP6populator_errors_20240119-185007.txt](https://github.com/crim-ca/stac-populator/files/14012790/stac-populator_CMIP6populator_errors_20240119-185007.txt)
