### PR TITLE
Fixes to datacube extension helper

### DIFF
--- a/STACpopulator/api_requests.py
+++ b/STACpopulator/api_requests.py
@@ -93,14 +93,16 @@ def post_stac_item(
     item_url = os.path.join(stac_host, f"collections/{collection_id}/items")
     r = session.post(item_url, json=json_data)
 
+    extra_log_info = {"item_id": item_id, "item_url": os.path.join(item_url, item_id)}
+
     if r.status_code == 200:
-        LOGGER.info(f"Item {item_name} successfully added")
+        LOGGER.info(f"Item {item_name} successfully added", extra=extra_log_info)
     elif r.status_code == 409:
         if update:
-            LOGGER.info(f"Item {item_id} already exists. Updating.")
+            LOGGER.info(f"Item {item_id} already exists. Updating.", extra=extra_log_info)
             r = session.put(os.path.join(stac_host, f"collections/{collection_id}/items/{item_id}"), json=json_data)
             r.raise_for_status()
         else:
-            LOGGER.warn(f"Item {item_id} already exists.")
+            LOGGER.warn(f"Item {item_id} already exists.", extra=extra_log_info)
     else:
         r.raise_for_status()

--- a/STACpopulator/extensions/datacube.py
+++ b/STACpopulator/extensions/datacube.py
@@ -225,6 +225,11 @@ class DataCubeHelper:
 
     def is_coordinate(self, attrs: MutableMapping[str, Any]) -> bool:
         """Return whether variable is a coordinate."""
+
+        if (desc := attrs.get("description", None)) is not None:
+            if "bounds for" in desc:
+                return True
+
         for key, criteria in self.coordinate_criteria.items():
             for criterion, expected in criteria.items():
                 if attrs.get(criterion, None) in expected:

--- a/STACpopulator/extensions/datacube.py
+++ b/STACpopulator/extensions/datacube.py
@@ -191,7 +191,12 @@ class DataCubeHelper:
             if name in self.attrs["dimensions"]:
                 continue
 
-            attrs = meta["attributes"]
+            try:
+                attrs = meta["attributes"]
+            except KeyError:
+                # Some variables like "time_bnds" in some model files do not have any attributes.
+                attrs = {}
+
             variables[name] = Variable(
                 properties=dict(
                     dimensions=meta["shape"],

--- a/STACpopulator/extensions/datacube.py
+++ b/STACpopulator/extensions/datacube.py
@@ -189,11 +189,8 @@ class DataCubeHelper:
             if name in self.attrs["dimensions"]:
                 continue
 
-            try:
-                attrs = meta["attributes"]
-            except KeyError:
-                # Some variables like "time_bnds" in some model files do not have any attributes.
-                attrs = {}
+            # Some variables like "time_bnds" in some model files do not have any attributes.
+            attrs = meta.get("attributes", {})
 
             self._infer_variable_units_description(name, attrs)
 


### PR DESCRIPTION
1. Some variables (e.g. `time_bnds`) do not have variable "attributes" in certain model files. As a result the extension code crashes. [8621b6d](https://github.com/crim-ca/stac-populator/commit/8621b6d1e8513de93ca5c25a62e838aacd252ec8) fixes that.
2. As per CF convention bounds variables [are not required](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#cell-boundaries) to have attributes and that they should instead be inferred from the corresponding coordinate variables. [6326908](https://github.com/crim-ca/stac-populator/commit/63169082177784cb5c31f3e050571e7b1f662300) addresses that.

An example of how the data cube extension looks like with these changes is [here](https://daccs.cs.toronto.edu/stac/collections/CMIP6_UofT/items/CMIP_CAMS_CAMS-CSM1-0_historical_r2i1p1f1_Amon_ts_gn). 

An outstanding issue is that `time_bnds` variable is still not being inferred as an auxiliary variable. This will require a hack since this variable cannot be determined to be auxiliary using the framework currently [in place](https://github.com/crim-ca/stac-populator/blob/7e7adbfc0597e8277162ae62d429f9fcb0d424dd/STACpopulator/extensions/datacube.py#L205C1-L206C1) (because the variable in the netCDF file will not contain any of the "criteria" that could be put into place for the benefit of the `is_coordinate`).