### PR TITLE
Do not require pyessv archive

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pyessv-archive"]
-	path = pyessv-archive
-	url = https://github.com/dchandan/pyessv-archive

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * Adding collection links to `CMIP6_UofT`
 * Adding an end date to `CMIP6_UofT`'s temporal extent for better rendering in STAC Browser
 * Updates to datacube extension helper routines for `CMIP6_UofT`.
+* Make pyessv-archive a requirement for *only* the cmip6 implementation instead of for the whole CLI
 
 ## [0.6.0](https://github.com/crim-ca/stac-populator/tree/0.6.0) (2024-02-22)
 

--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,15 @@ STAC_HOST ?= http://localhost:8880/stac
 # CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/CMIP/NUIST/catalog.html
 CATALOG = https://daccs.cs.toronto.edu/twitcher/ows/proxy/thredds/catalog/datasets/CMIP6/CMIP/MIROC/catalog.html
 
-PYESSV_ARCHIVE_DIR ?= ~/.esdoc/pyessv-archive
+PYESSV_ARCHIVE_HOME ?= ~/.esdoc/pyessv-archive
 PYESSV_ARCHIVE_REF ?= https://github.com/ES-DOC/pyessv-archive
 
 ## -- Testing targets -------------------------------------------------------------------------------------------- ##
 
 setup-pyessv-archive:
-	@echo "Updating pyessv archive [$(shell realpath $(PYESSV_ARCHIVE_DIR))]..."
-	@[ -d $(PYESSV_ARCHIVE_DIR) ] || git clone "$(PYESSV_ARCHIVE_REF)" $(PYESSV_ARCHIVE_DIR)
-	@cd $(PYESSV_ARCHIVE_DIR) && git pull
+	@echo "Updating pyessv archive [$(shell realpath $(PYESSV_ARCHIVE_HOME))]..."
+	@[ -d $(PYESSV_ARCHIVE_HOME) ] || git clone "$(PYESSV_ARCHIVE_REF)" $(PYESSV_ARCHIVE_HOME)
+	@cd $(PYESSV_ARCHIVE_HOME) && git pull
 
 test-cmip6:
 	python $(IMP_DIR)/CMIP6_UofT/add_CMIP6.py $(STAC_HOST) $(CATALOG)

--- a/README.md
+++ b/README.md
@@ -49,17 +49,48 @@ You should then be able to call the STAC populator CLI with following commands:
 
 ```shell
 # obtain the installed version of the STAC populator
-stac-popultaor --version
+stac-populator --version
 
 # obtain general help about available commands
-stac-popultaor --help
+stac-populator --help
 
 # obtain general help about available STAC populator implementations
-stac-popultaor run --help
+stac-populator run --help
 
 # obtain help specifically for the execution of a STAC populator implementation
-stac-popultaor run [implementation] --help
+stac-populator run [implementation] --help
 ```
+
+### CMIP6 extension: extra requirements
+
+The CMIP6 stac-populator extension requires that the [pyessv-archive](https://github.com/ES-DOC/pyessv-archive) data 
+files be installed. To install this package to the default location in your home directory at `~/.esdoc/pyessv-archive`:
+
+```shell
+git clone https://github.com/ES-DOC/pyessv-archive ~/.esdoc/pyessv-archive
+# OR
+make setup-pyessv-archive
+```
+
+You can also choose to install them to a location on disk other than the default:
+
+```shell
+git clone https://github.com/ES-DOC/pyessv-archive /some/other/place
+# OR
+PYESSV_ARCHIVE_HOME=/some/other/place make setup-pyessv-archive
+```
+
+*Note*: <br>
+If you have installed the [pyessv-archive](https://github.com/ES-DOC/pyessv-archive) data files to a non-default
+location, you need to specify that location with the `PYESSV_ARCHIVE_HOME` environment variable. For example,
+if you've installed the pyessv-archive files to `/some/other/place` then run the following before executing 
+any of the example commands above:
+
+```shell
+export PYESSV_ARCHIVE_HOME=/some/other/place
+```
+
+### Docker
 
 You can also employ the pre-built Docker, which can be called as follows,
 where `[command]` corresponds to any of the above example operations.

--- a/STACpopulator/exceptions.py
+++ b/STACpopulator/exceptions.py
@@ -1,0 +1,5 @@
+class STACPopulatorError(Exception):
+    pass
+
+class ExtensionLoadError(STACPopulatorError):
+    pass

--- a/STACpopulator/extensions/cmip6.py
+++ b/STACpopulator/extensions/cmip6.py
@@ -15,7 +15,6 @@ from typing import (
     get_args,
 )
 
-import pyessv
 import pystac
 from pydantic import (
     AnyHttpUrl,
@@ -34,6 +33,7 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 
+from STACpopulator.exceptions import ExtensionLoadError
 from STACpopulator.models import AnyGeometry
 from STACpopulator.stac_utils import (
     ServiceType,
@@ -41,6 +41,11 @@ from STACpopulator.stac_utils import (
     ncattrs_to_bbox,
     ncattrs_to_geometry,
 )
+
+try:
+    import pyessv
+except OSError as e:
+    raise ExtensionLoadError(str(e)) from e
 
 T = TypeVar("T", pystac.Collection, pystac.Item, pystac.Asset, item_assets.AssetDefinition)
 


### PR DESCRIPTION
The pyessv-archive is required to run any stac-populator CLI commands but should only be required to run the CMIP6 populator. 

This PR allows the CLI to work as intended even if pyessv-archive is not installed. Instead of exiting with an error, it will show a warning and continue to provide all other functionality that does not require pyessv-archive to run.

Current behaviour:

```
$ stac-populator --help
Traceback (most recent call last):
...
...
STACpopulator.exceptions.ExtensionLoadError: /home/.../.esdoc/pyessv-archive directory does not exists
```

After this PR behaviour:

```
$ stac-populator --help
.../stac-populator/STACpopulator/cli.py:159: UserWarning: Could not load extension CMIP6_UofT because of error /home/mschwa/.esdoc/pyessv-archive directory does not exists
  warnings.warn(f"Could not load extension {populator_name} because of error {e}")
usage: stac-populator [-h] [--version] [--debug] {run} ...
```

This PR also updates the README.md to clarify the dependency on pyessv-archive and fixes some minor typos.

Finally, it changes the `PYESSV_ARCHIVE_DIR` variable in the Makefile to `PYESSV_ARCHIVE_HOME` which is the variable used by the [pyessv](https://github.com/ES-DOC/pyessv) project. This means that users who wish to install the archive in a non-default location only need to set one variable, not two.