### PR TITLE
ignore pyessv-archive locally since not a git submodule anymore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,8 @@ reports
 STACpopulator.egg-info/
 build
 *.pyc
+
+# Old Submodule Path
+# Could be used locally
+pyessv-archive
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ build
 ## Logs
 *.jsonl
 *.json
+
+# Old Submodule Path
+# Could be used locally
+pyessv-archive/
+


### PR DESCRIPTION
relates to #58 