### PR TITLE
fix tests to allow for variable STAC versions in output

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,8 @@
 * move argument parsing for logging options to the implementation code
 * fix bug where logging options were being set incorrectly
 * rename files to avoid potential naming conflicts with other packages (`logging` and `requests`)
-
+* enforce versions for dependencies so that new installs won't fail unexpectedly
+* update tests to allow for a variable `stac_version` field in STAC item and collections 
 
 ## [0.6.0](https://github.com/crim-ca/stac-populator/tree/0.6.0) (2024-02-22)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,15 +105,15 @@ version = "0.6.0"
 description = "Utility to populate STAC Catalog, Collections and Items from various dataset/catalog sources."
 requires-python = ">=3.10"
 dependencies = [
-    "colorlog",
-    "pyyaml",
-    "siphon",
-    "pystac",
-    "xncml>=0.3.1",  # python 3.12 support
-    "pydantic>=2",
-    "pyessv",
-    "requests",
-    "lxml",
+    "colorlog~=6.9",
+    "pyyaml~=6.0",
+    "siphon~=0.10",
+    "pystac~=1.12",
+    "xncml~=0.3",  # python 3.12 support
+    "pydantic~=2.10",
+    "pyessv~=0.9",
+    "requests~=2.32",
+    "lxml~=5.3",
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -162,12 +162,11 @@ Changelog = "https://github.com/crim-ca/stac-populator/blob/master/CHANGES.md"
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "pytest-cov",
-    "coverage",
-    "responses",
-    "bump-my-version",
-    "jsonschema",
-    "pystac[validation]>=1.9.0"
+    "pytest~=8.3",
+    "pytest-cov~=6.0",
+    "coverage~=7.6",
+    "responses~=0.25",
+    "bump-my-version~=0.32",
+    "jsonschema~=4.23",
+    "pystac[validation]~=1.12"
 ]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dependencies = [
     "colorlog~=6.9",
     "pyyaml~=6.0",
     "siphon~=0.10",
-    "pystac~=1.12",
+    "pystac~=1.12.1",
     "xncml~=0.3",  # python 3.12 support
     "pydantic~=2.10",
     "pyessv~=0.9",
@@ -168,5 +168,5 @@ dev = [
     "responses~=0.25",
     "bump-my-version~=0.32",
     "jsonschema~=4.23",
-    "pystac[validation]~=1.12"
+    "pystac[validation]~=1.12.1"
 ]

--- a/tests/test_standalone_stac_item.py
+++ b/tests/test_standalone_stac_item.py
@@ -6,6 +6,7 @@ import tempfile
 from urllib.parse import quote
 
 import xncml
+from pystac.version import get_stac_version
 
 from STACpopulator.extensions.cmip6 import CMIP6Helper
 from STACpopulator.extensions.thredds import THREDDSHelper, THREDDSExtension
@@ -50,6 +51,7 @@ def test_standalone_stac_item_thredds_ncml():
     ref_file = os.path.join(CUR_DIR, "data/stac_item_testdata_xclim_cmip6_ncml.json")
     with open(ref_file, mode="r", encoding="utf-8") as ff:
         reference = json.load(ff)
+        reference["stac_version"] = get_stac_version()
 
     assert stac_item.to_dict() == reference
 
@@ -86,5 +88,6 @@ def test_cmip6_stac_thredds_catalog_parsing():
     ref_file = os.path.join(CUR_DIR, "data/stac_collection_testdata_xclim_cmip6_catalog.json")
     with open(ref_file, mode="r", encoding="utf-8") as ff:
         reference = json.load(ff)
+        reference["stac_version"] = get_stac_version()
 
     assert result == reference

--- a/tests/test_standalone_stac_item.py
+++ b/tests/test_standalone_stac_item.py
@@ -1,4 +1,5 @@
 import json
+import pystac
 import pytest
 import requests
 import os
@@ -6,7 +7,6 @@ import tempfile
 from urllib.parse import quote
 
 import xncml
-from pystac.version import get_stac_version
 
 from STACpopulator.extensions.cmip6 import CMIP6Helper
 from STACpopulator.extensions.thredds import THREDDSHelper, THREDDSExtension
@@ -50,8 +50,7 @@ def test_standalone_stac_item_thredds_ncml():
 
     ref_file = os.path.join(CUR_DIR, "data/stac_item_testdata_xclim_cmip6_ncml.json")
     with open(ref_file, mode="r", encoding="utf-8") as ff:
-        reference = json.load(ff)
-        reference["stac_version"] = get_stac_version()
+        reference = pystac.Item.from_dict(json.load(ff)).to_dict()
 
     assert stac_item.to_dict() == reference
 
@@ -87,7 +86,6 @@ def test_cmip6_stac_thredds_catalog_parsing():
 
     ref_file = os.path.join(CUR_DIR, "data/stac_collection_testdata_xclim_cmip6_catalog.json")
     with open(ref_file, mode="r", encoding="utf-8") as ff:
-        reference = json.load(ff)
-        reference["stac_version"] = get_stac_version()
+        reference = pystac.Collection.from_dict(json.load(ff)).to_dict()
 
     assert result == reference


### PR DESCRIPTION
Tests currently assume that the STAC version in item and collection JSONs will always be `1.0.0`.
Since we don't pin a specific version of `pystac`, a new version of `pystac` uses STAC version `1.1.0` which now causes tests to fail.

This PR updates tests to allow for item and collection JSONs to have a `stac_version` field that matches the version used by the installed version of `pystac`.

As part of this PR, I also updated the dependency versions to not allow major version upgrades automatically. For example, `pystac` is now pinned to version `~=1.12` which will mean is will not install version 2+. This should avoid similar breaking changes caused by dependency updates in the future.