### PR TITLE
allow populators to be called directly from the command line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 * move argument parsing for logging options to the implementation code
 * fix bug where logging options were being set incorrectly
 * rename files to avoid potential naming conflicts with other packages (`logging` and `requests`)
-
+* fix bug where populator scripts could not be called directly from the command line
 
 ## [0.6.0](https://github.com/crim-ca/stac-populator/tree/0.6.0) (2024-02-22)
 

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -133,6 +133,7 @@ def main(*args: str) -> int:
     add_parser_args(parser)
     ns = parser.parse_args(args or None)
     ns.populator = os.path.basename(os.path.dirname(__file__))
+    ns.command = "run"
     return cli.run(ns)
 
 if __name__ == "__main__":

--- a/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
+++ b/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
@@ -74,6 +74,7 @@ def main(*args: str) -> int:
     add_parser_args(parser)
     ns = parser.parse_args(args or None)
     ns.populator = os.path.basename(os.path.dirname(__file__))
+    ns.command = "run"
     return cli.run(ns)
 
 


### PR DESCRIPTION
Fix a bug where an argparse namespace value was not being added when populators were called directly from the command line