### PR TITLE
deprecate calling implementation scripts directly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 * move argument parsing for logging options to the implementation code
 * fix bug where logging options were being set incorrectly
 * rename files to avoid potential naming conflicts with other packages (`logging` and `requests`)
-
+* deprecate calling implementation scripts directly
 
 ## [0.6.0](https://github.com/crim-ca/stac-populator/tree/0.6.0) (2024-02-22)
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ setup-pyessv-archive:
 	@cd $(PYESSV_ARCHIVE_HOME) && git pull
 
 test-cmip6:
-	python $(IMP_DIR)/CMIP6_UofT/add_CMIP6.py $(STAC_HOST) $(CATALOG)
+	stac-populator run CMIP6_UofT $(STAC_HOST) $(CATALOG)
 
 del-cmip6:
 	curl --location --request DELETE '$(STAC_HOST)/collections/CMIP6_UofT'

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 from typing import Any, MutableMapping, Optional, Union
+import warnings
 
 from pystac import STACValidationError
 from pystac.extensions.datacube import DatacubeExtension
@@ -129,6 +130,10 @@ def runner(ns: argparse.Namespace) -> int:
 
 
 def main(*args: str) -> int:
+    warnings.warn(
+        "Calling implementation scripts directly is deprecated. Please use the 'stac-populator' CLI instead.",
+        DeprecationWarning
+    )
     parser = argparse.ArgumentParser()
     add_parser_args(parser)
     ns = parser.parse_args(args or None)

--- a/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
+++ b/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 import sys
 from typing import Any, MutableMapping, Optional
+import warnings
 
 from requests.sessions import Session
 
@@ -70,6 +71,10 @@ def runner(ns: argparse.Namespace) -> int:
 
 
 def main(*args: str) -> int:
+    warnings.warn(
+        "Calling implementation scripts directly is deprecated. Please use the 'stac-populator' CLI instead.",
+        DeprecationWarning
+    )
     parser = argparse.ArgumentParser()
     add_parser_args(parser)
     ns = parser.parse_args(args or None)


### PR DESCRIPTION
See additional discussion:

- https://github.com/crim-ca/stac-populator/pull/60#discussion_r1794048011
- https://github.com/crim-ca/stac-populator/pull/66#discussion_r1806456102