### PR TITLE
fix inconsistent update defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 * fix bug where populator scripts could not be called directly from the command line
 * enforce versions for dependencies so that new installs won't fail unexpectedly
 * update tests to allow for a variable `stac_version` field in STAC item and collections 
+* fix inconsistent defaults for parameters that update stac items and collections
 
 
 ## [0.6.0](https://github.com/crim-ca/stac-populator/tree/0.6.0) (2024-02-22)

--- a/STACpopulator/api_requests.py
+++ b/STACpopulator/api_requests.py
@@ -35,7 +35,7 @@ def stac_collection_exists(stac_host: str, collection_id: str, session: Optional
 def post_stac_collection(
     stac_host: str,
     json_data: dict[str, Any],
-    update: Optional[bool] = True,
+    update: Optional[bool] = False,
     session: Optional[Session] = None,
 ) -> None:
     """Post/create a collection on the STAC host

--- a/STACpopulator/extensions/cmip6.py
+++ b/STACpopulator/extensions/cmip6.py
@@ -179,7 +179,7 @@ class CMIP6Helper:
         props = CMIP6Properties(**self.cmip6_attrs)
         return props
 
-    def stac_item(self) -> "pystac.Item":
+    def stac_item(self, add_if_missing: bool = False) -> "pystac.Item":
         item = pystac.Item(
             id=self.uid,
             geometry=self.geometry.model_dump(),
@@ -190,7 +190,7 @@ class CMIP6Helper:
             },
             datetime=None,
         )
-        item_cmip6 = CMIP6Extension.ext(item, add_if_missing=True)
+        item_cmip6 = CMIP6Extension.ext(item, add_if_missing=add_if_missing)
         item_cmip6.apply(self.properties)
         return item
 

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -60,14 +60,14 @@ class CMIP6populator(STACpopulatorBase):
         # Add CMIP6 extension
         try:
             cmip_helper = CMIP6Helper(item_data, self.item_geometry_model)
-            item = cmip_helper.stac_item()
+            item = cmip_helper.stac_item(add_if_missing=self.update)
         except Exception as e:
             raise Exception("Failed to add CMIP6 extension") from e
 
         # Add datacube extension
         try:
             dc_helper = DataCubeHelper(item_data)
-            dc_ext = DatacubeExtension.ext(item, add_if_missing=True)
+            dc_ext = DatacubeExtension.ext(item, add_if_missing=self.update)
             dc_ext.apply(dimensions=dc_helper.dimensions, variables=dc_helper.variables)
         except Exception as e:
             raise Exception("Failed to add Datacube extension") from e

--- a/tests/test_cmip6_datacube.py
+++ b/tests/test_cmip6_datacube.py
@@ -17,7 +17,7 @@ def test_datacube_helper():
     ds = xncml.Dataset(filepath=str(file_path))
     attrs = ds.to_cf_dict()
     attrs["access_urls"] = {"HTTPServer": "http://example.com"}
-    item = CMIP6Helper(attrs, GeoJSONPolygon).stac_item()
+    item = CMIP6Helper(attrs, GeoJSONPolygon).stac_item(add_if_missing=True)
 
     # Add extension
     dc = DataCubeHelper(attrs)
@@ -45,7 +45,7 @@ def test_auxiliary_variables():
     ds = xncml.Dataset(filepath=str(file_path))
     attrs = ds.to_cf_dict()
     attrs["access_urls"] = {"HTTPServer": "http://example.com"}
-    item = CMIP6Helper(attrs, GeoJSONPolygon).stac_item()
+    item = CMIP6Helper(attrs, GeoJSONPolygon).stac_item(add_if_missing=True)
 
     dc = DataCubeHelper(attrs)
     dc_ext = DatacubeExtension.ext(item, add_if_missing=True)

--- a/tests/test_standalone_stac_item.py
+++ b/tests/test_standalone_stac_item.py
@@ -43,7 +43,7 @@ def test_standalone_stac_item_thredds_ncml():
         "WMS": f"{thredds_url}/wms/{thredds_path}/{thredds_nc}?service=WMS&version=1.3.0&request=GetCapabilities",
         "NetcdfSubset": f"{thredds_url}/ncss/{thredds_path}/{thredds_nc}/dataset.html",
     }
-    stac_item = CMIP6Helper(attrs, GeoJSONPolygon).stac_item()
+    stac_item = CMIP6Helper(attrs, GeoJSONPolygon).stac_item(add_if_missing=True)
     thredds_helper = THREDDSHelper(attrs["access_urls"])
     thredds_ext = THREDDSExtension.ext(stac_item)
     thredds_ext.apply(services=thredds_helper.services, links=thredds_helper.links)


### PR DESCRIPTION
resolves #80 
closes #82

I'm a little confused now what is supposed to happen if  the `--update` flag is not used. Is it supposed to create items/collections/assets only if they don't exist? Is it supposed to report the status of something?
All of the tests currently assume that `--update` is set and I think that we should add some tests for the opposite case but I don't understand what the intended outcome is... :man_shrugging: 