### PR TITLE
Remove option to call implementations directly (deprecated) and reorganized CLI arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Add an `xscen` extension demonstrating how to add properties to a STAC Item.
 * Fix mismatch between CMIP6 schema URI given to `pystac` and the actual schema URI
 * Add ability to export data from a STAC catalog or API to files on disk.
+* Reorganize command line arguments to ensure shared options are always applied.
 
 ## [0.7.0](https://github.com/crim-ca/stac-populator/tree/0.7.0) (2025-03-07)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * Fix mismatch between CMIP6 schema URI given to `pystac` and the actual schema URI
 * Add ability to export data from a STAC catalog or API to files on disk.
 * Reorganize command line arguments to ensure shared options are always applied.
+* Remove option to call implementation scripts directly from the command line.
 
 ## [0.7.0](https://github.com/crim-ca/stac-populator/tree/0.7.0) (2025-03-07)
 

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -6,6 +6,7 @@ import sys
 import warnings
 from types import ModuleType
 
+import pystac
 import requests
 
 from STACpopulator import __version__, implementations
@@ -24,10 +25,19 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
         version=f"%(prog)s {__version__}",
         help="prints the version of the library and exits",
     )
+    add_logging_options(parser)
+    add_request_options(parser)
     commands_subparser = parser.add_subparsers(
         title="command", dest="command", description="STAC populator command to execute.", required=True
     )
     run_parser = commands_subparser.add_parser("run", description="Run a STACpopulator implementation")
+    run_parser.add_argument(
+        "--stac-version",
+        help="Sets the STAC version that should be used. This must match the version used by "
+        "the STAC server that is being populated. This can also be set by setting the "
+        "'PYSTAC_STAC_VERSION_OVERRIDE' environment variable. "
+        f"Default is {pystac.get_stac_version()}",
+    )
     populators_subparser = run_parser.add_subparsers(
         title="populator", dest="populator", description="Implementation to run."
     )
@@ -43,8 +53,6 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Do not raise an error if STAC items with the same ids are found in a collection.",
     )
-    add_request_options(export_parser)
-    add_logging_options(export_parser)
 
 
 @functools.cache
@@ -68,11 +76,13 @@ def implementation_modules() -> dict[str, ModuleType]:
 def run(ns: argparse.Namespace) -> int:
     """Run a given implementation given the arguments passed on the command line."""
     setup_logging(ns.log_file, ns.debug or logging.INFO)
-    if ns.command == "run":
-        return implementation_modules()[ns.populator].runner(ns) or 0
-    else:
-        with requests.Session() as session:
-            apply_request_options(session, ns)
+    with requests.Session() as session:
+        apply_request_options(session, ns)
+        if ns.command == "run":
+            if ns.stac_version:
+                pystac.set_stac_version(ns.stac_version)
+            return implementation_modules()[ns.populator].runner(ns, session) or 0
+        else:
             return export_catalog(ns.directory, ns.stac_host, session, ns.resume, ns.ignore_duplicate_ids) or 0
 
 

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -2,15 +2,12 @@ import argparse
 import json
 import logging
 import os
-import sys
-import warnings
 from typing import Any, MutableMapping, Optional, Union
 
 from pystac import STACValidationError
 from pystac.extensions.datacube import DatacubeExtension
 from requests.sessions import Session
 
-from STACpopulator import cli
 from STACpopulator.extensions.cmip6 import CMIP6Helper, CMIP6Properties
 from STACpopulator.extensions.datacube import DataCubeHelper
 from STACpopulator.extensions.thredds import THREDDSExtension, THREDDSHelper
@@ -115,21 +112,3 @@ def runner(ns: argparse.Namespace, session: Session) -> int:
     c = CMIP6populator(ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config)
     c.ingest()
     return 0
-
-
-def main(*args: str) -> int:
-    """Call this implementation directly."""
-    warnings.warn(
-        "Calling implementation scripts directly is deprecated. Please use the 'stac-populator' CLI instead.",
-        DeprecationWarning,
-    )
-    parser = argparse.ArgumentParser()
-    add_parser_args(parser)
-    ns = parser.parse_args(args or None)
-    ns.populator = os.path.basename(os.path.dirname(__file__))
-    ns.command = "run"
-    return cli.run(ns)
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
+++ b/STACpopulator/implementations/CMIP6_UofT/add_CMIP6.py
@@ -6,7 +6,6 @@ import sys
 import warnings
 from typing import Any, MutableMapping, Optional, Union
 
-import pystac
 from pystac import STACValidationError
 from pystac.extensions.datacube import DatacubeExtension
 from requests.sessions import Session
@@ -16,10 +15,8 @@ from STACpopulator.extensions.cmip6 import CMIP6Helper, CMIP6Properties
 from STACpopulator.extensions.datacube import DataCubeHelper
 from STACpopulator.extensions.thredds import THREDDSExtension, THREDDSHelper
 from STACpopulator.input import ErrorLoader, GenericLoader, THREDDSLoader
-from STACpopulator.log import add_logging_options
 from STACpopulator.models import GeoJSONPolygon
 from STACpopulator.populator_base import STACpopulatorBase
-from STACpopulator.request_utils import add_request_options, apply_request_options
 
 LOGGER = logging.getLogger(__name__)
 
@@ -103,34 +100,20 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
             "By default, uses the adjacent configuration to the implementation class."
         ),
     )
-    parser.add_argument(
-        "--stac-version",
-        help="Sets the STAC version that should be used. This must match the version used by "
-        "the STAC server that is being populated. This can also be set by setting the "
-        "'PYSTAC_STAC_VERSION_OVERRIDE' environment variable. "
-        f"Default is {pystac.get_stac_version()}",
-    )
-    add_request_options(parser)
-    add_logging_options(parser)
 
 
-def runner(ns: argparse.Namespace) -> int:
+def runner(ns: argparse.Namespace, session: Session) -> int:
     """Run the populator."""
     LOGGER.info(f"Arguments to call: {vars(ns)}")
 
-    if ns.stac_version:
-        pystac.set_stac_version(ns.stac_version)
+    if ns.mode == "full":
+        data_loader = THREDDSLoader(ns.href, session=session)
+    else:
+        # To be implemented
+        data_loader = ErrorLoader()
 
-    with Session() as session:
-        apply_request_options(session, ns)
-        if ns.mode == "full":
-            data_loader = THREDDSLoader(ns.href, session=session)
-        else:
-            # To be implemented
-            data_loader = ErrorLoader()
-
-        c = CMIP6populator(ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config)
-        c.ingest()
+    c = CMIP6populator(ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config)
+    c.ingest()
     return 0
 
 

--- a/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
+++ b/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
@@ -6,9 +6,7 @@ from requests.sessions import Session
 
 from STACpopulator.extensions.cordex6 import Cordex6DataModel
 from STACpopulator.input import ErrorLoader, THREDDSLoader
-from STACpopulator.log import add_logging_options
 from STACpopulator.populator_base import STACpopulatorBase
-from STACpopulator.request_utils import add_request_options, apply_request_options
 
 LOGGER = logging.getLogger(__name__)
 
@@ -46,24 +44,20 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
             "By default, uses the adjacent configuration to the implementation class."
         ),
     )
-    add_request_options(parser)
-    add_logging_options(parser)
 
 
-def runner(ns: argparse.Namespace) -> int:
+def runner(ns: argparse.Namespace, session: Session) -> int:
     """Run the populator."""
     LOGGER.info(f"Arguments to call: {vars(ns)}")
 
-    with Session() as session:
-        apply_request_options(session, ns)
-        if ns.mode == "full":
-            data_loader = THREDDSLoader(ns.href, session=session)
-        else:
-            # To be implemented
-            data_loader = ErrorLoader()
+    if ns.mode == "full":
+        data_loader = THREDDSLoader(ns.href, session=session)
+    else:
+        # To be implemented
+        data_loader = ErrorLoader()
 
-        c = CORDEX_STAC_Populator(
-            ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config, log_debug=ns.debug
-        )
-        c.ingest()
+    c = CORDEX_STAC_Populator(
+        ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config, log_debug=ns.debug
+    )
+    c.ingest()
     return 0

--- a/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
+++ b/STACpopulator/implementations/DirectoryLoader/crawl_directory.py
@@ -1,14 +1,11 @@
 import argparse
 import logging
 import os.path
-import sys
-import warnings
 from typing import Any, MutableMapping, Optional
 
 import pystac
 from requests.sessions import Session
 
-from STACpopulator import cli
 from STACpopulator.input import STACDirectoryLoader
 from STACpopulator.models import GeoJSONPolygon
 from STACpopulator.populator_base import STACpopulatorBase
@@ -80,21 +77,3 @@ def runner(ns: argparse.Namespace, session: Session) -> int:
         populator = DirectoryPopulator(ns.stac_host, loader, ns.update, collection_json, session=session)
         populator.ingest()
     return 0
-
-
-def main(*args: str) -> int:
-    """Call this implementation directly."""
-    warnings.warn(
-        "Calling implementation scripts directly is deprecated. Please use the 'stac-populator' CLI instead.",
-        DeprecationWarning,
-    )
-    parser = argparse.ArgumentParser()
-    add_parser_args(parser)
-    ns = parser.parse_args(args or None)
-    ns.populator = os.path.basename(os.path.dirname(__file__))
-    ns.command = "run"
-    return cli.run(ns)
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/tests/test_directory_loader.py
+++ b/tests/test_directory_loader.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Generator
 
 import pystac
 import pytest
+import requests
 import responses
 
 from STACpopulator.cli import add_parser_args
@@ -131,7 +132,8 @@ class _TestDirectoryLoader(abc.ABC):
 class TestModule(_TestDirectoryLoader):
     @pytest.fixture
     def runner(self, namespace: argparse.Namespace) -> Callable:
-        return functools.partial(crawl_directory.runner, namespace)
+        with requests.Session() as session:
+            return functools.partial(crawl_directory.runner, namespace, session)
 
     @pytest.fixture
     def namespace(self, request: pytest.FixtureRequest, prune_option: bool) -> argparse.Namespace:
@@ -160,11 +162,11 @@ class TestFromCLI(_TestDirectoryLoader):
     @pytest.fixture
     def args(self, request: pytest.FixtureRequest, prune_option: bool) -> list[str]:
         cmd_args = [
+            "--no-verify",
             "run",
             "DirectoryLoader",
             "http://example.com/stac/",
             os.path.join(request.fspath.dirname, "data/test_directory"),
-            "--no-verify",
             "--update",
         ]
         if prune_option:


### PR DESCRIPTION
This removes the option to call implementation scripts directly (this had been previously deprecated).

This allows us to re-organize the way that CLI options are organized to ensure that options that are common to all implementations are added in cli.py and are not required to be added every time for each implementation. 

These common options are:

- logging options: added in log.py
- request options: added in request_utils.py