### PR TITLE
Fix cordex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 * Include `PYESSV_ARCHIVE_HOME` environment variable in Dockerfile.
 * Remove redundant CLI arguments.
+* Fix bug in `THREDDSLoader` iterator introduced in 0.8.0. 
+* Remove `log_debug` option from CORDEX-CMIP6_Ouranos' runner. 
+* Add attributes to CORDEX IDs to avoid duplicate IDs in the STAC catalog.
+* Update CORDEX-CMIP6_Ouranos' test data. 
 
 ## [0.8.0](https://github.com/crim-ca/stac-populator/tree/0.8.0) (2025-06-11)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,10 @@
 
 * Include `PYESSV_ARCHIVE_HOME` environment variable in Dockerfile.
 * Remove redundant CLI arguments.
-* Fix bug in `THREDDSLoader` iterator introduced in 0.8.0. 
-* Remove `log_debug` option from CORDEX-CMIP6_Ouranos' runner. 
+* Fix bug in `THREDDSLoader` iterator introduced in 0.8.0. Simple iteration over `catalog_refs` returns the catalog names (strings), whereas we want an object with a `follow` method. 
+* Remove `log_debug` option from the `CORDEXCMIP6_Ouranos` runner. 
 * Add attributes to CORDEX IDs to avoid duplicate IDs in the STAC catalog.
-* Update CORDEX-CMIP6_Ouranos' test data. 
+* Update test data for `CORDEXCMIP6_Ouranos`. 
 
 ## [0.8.0](https://github.com/crim-ca/stac-populator/tree/0.8.0) (2025-06-11)
 

--- a/STACpopulator/extensions/cordex6.py
+++ b/STACpopulator/extensions/cordex6.py
@@ -65,8 +65,10 @@ class Cordex6DataModel(THREDDSCatalogDataModel):
             "source_id",
             "driving_experiment_id",
             "driving_variant_label",
+            "version_realization",
             "variable_id",
             "domain_id",
+            "frequency",
         ]
         values = [getattr(self.cordex6, k) for k in keys]
         values.append(self.start_datetime.strftime("%Y%m%d"))

--- a/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
+++ b/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
@@ -57,7 +57,11 @@ def runner(ns: argparse.Namespace, session: Session) -> int:
         data_loader = ErrorLoader()
 
     c = CORDEX_STAC_Populator(
-        ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config,
+        ns.stac_host,
+        data_loader,
+        update=ns.update,
+        session=session,
+        config_file=ns.config,
     )
     c.ingest()
     return 0

--- a/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
+++ b/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
@@ -57,7 +57,7 @@ def runner(ns: argparse.Namespace, session: Session) -> int:
         data_loader = ErrorLoader()
 
     c = CORDEX_STAC_Populator(
-        ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config, log_debug=ns.debug
+        ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config,
     )
     c.ingest()
     return 0

--- a/STACpopulator/input.py
+++ b/STACpopulator/input.py
@@ -103,7 +103,7 @@ class THREDDSLoader(GenericLoader):
                 url = f"{current_catalog.catalog_url}?dataset={dataset.id}"
                 yield item_name, url, attrs
 
-            for ref in current_catalog.catalog_refs:
+            for name, ref in current_catalog.catalog_refs.items():
                 catalogs.put(ref.follow())
 
     def __getitem__(self, dataset: str) -> dict:

--- a/tests/data/cordex6_ncml.json
+++ b/tests/data/cordex6_ncml.json
@@ -39,6 +39,7 @@
     "version_realization": "v1-r1",
     "institution": "Ouranos Consortium on Regional Climatology and Adaptation to Climate Change",
     "NCO": "netCDF Operators version 5.1.8 (Homepage = http://nco.sf.net, Code = http://github.com/nco/nco, Citation = 10.1016/j.envsoft.2008.03.004)",
+    "futher_info_url": "https://zenodo.org/doi/10.5281/zenodo.11061924",
     "abstract": "Ouranos produces operational regional climate simulations over the Cordex North American domain, at 0.11\u00b0 resolution. The current ensemble uses the fifth version of the CRCM, developed at UQAM's ESCER center in collaboration with ECCC. Pilot data for the simulations come from the CMIP6 ensemble, except for those in hindcast mode, which use ERA5.",
     "dataset_id": "CRCM5-CMIP6",
     "license_type": "permissive",
@@ -87,7 +88,7 @@
     },
     "NCISOMetadata": {
       "attributes": {
-        "metadata_creation": "2025-03-06",
+        "metadata_creation": "2025-06-25",
         "nciso_version": "2.4.6"
       }
     }
@@ -111,6 +112,9 @@
         "axis": "Y",
         "standard_name": "grid_latitude",
         "bounds": "rlat_bounds",
+        "_ChunkSizes": [
+          628
+        ],
         "_CoordinateAxisType": "GeoY"
       }
     },
@@ -132,6 +136,9 @@
         "standard_name": "grid_longitude",
         "bounds": "rlon_bounds",
         "units": "degrees",
+        "_ChunkSizes": [
+          655
+        ],
         "_CoordinateAxisType": "GeoX"
       }
     },
@@ -146,6 +153,9 @@
         ],
         "units": "days since 1950-01-01",
         "calendar": "standard",
+        "_ChunkSizes": [
+          512
+        ],
         "_CoordinateAxisType": "Time"
       }
     },
@@ -180,7 +190,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "vertices_longitude": {
@@ -194,7 +209,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "tas": {
@@ -217,7 +237,12 @@
         ],
         "units": "K",
         "grid_mapping": "crs",
-        "coordinates": "height lat lon"
+        "coordinates": "height lat lon",
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
       }
     },
     "pr": {
@@ -240,7 +265,12 @@
         ],
         "units": "kg m-2 s-1",
         "grid_mapping": "crs",
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
       }
     },
     "time_bnds": {
@@ -252,6 +282,90 @@
       "attributes": {
         "_FillValue": [
           NaN
+        ],
+        "_ChunkSizes": [
+          1,
+          2
+        ]
+      }
+    },
+    "quantization_info": {
+      "shape": [
+        ""
+      ],
+      "type": "char",
+      "attributes": {
+        "algorithm": "bitround",
+        "implementation": "NCO version 5.3.2"
+      }
+    },
+    "prsn": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "Snowfall Flux",
+        "_FillValue": [
+          1.0000000200408773e+20
+        ],
+        "standard_name": "snowfall_flux",
+        "cell_measures": "area: areacella",
+        "cell_methods": "area: time: mean",
+        "missing_value": [
+          1.0000000200408773e+20
+        ],
+        "units": "kg m-2 s-1",
+        "grid_mapping": "crs",
+        "coordinates": "lat lon",
+        "quantization": "quantization_info",
+        "quantization_nsb": [
+          12
+        ],
+        "quantization_maximum_relative_error": [
+          0.0001220703125
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
+      }
+    },
+    "snw": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "Surface Snow Amount",
+        "_FillValue": [
+          1.0000000200408773e+20
+        ],
+        "standard_name": "surface_snow_amount",
+        "cell_measures": "area: areacella",
+        "cell_methods": "area: mean where land time: point",
+        "missing_value": [
+          1.0000000200408773e+20
+        ],
+        "units": "kg m-2",
+        "grid_mapping": "crs",
+        "coordinates": "lat lon",
+        "quantization": "quantization_info",
+        "quantization_nsb": [
+          12
+        ],
+        "quantization_maximum_relative_error": [
+          0.0001220703125
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
         ]
       }
     },
@@ -275,6 +389,11 @@
         "coordinates": "height lat lon",
         "missing_value": [
           1.0000000200408773e+20
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
         ]
       }
     },
@@ -298,6 +417,11 @@
         "coordinates": "height lat lon",
         "missing_value": [
           1.0000000200408773e+20
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
         ]
       }
     },
@@ -333,6 +457,10 @@
         "standard_name": "latitude",
         "units": "degrees_north",
         "bounds": "vertices_latitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lat"
       }
     },
@@ -350,6 +478,10 @@
         "standard_name": "longitude",
         "units": "degrees_east",
         "bounds": "vertices_longitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lon"
       }
     }

--- a/tests/data/cordex6_raw.json
+++ b/tests/data/cordex6_raw.json
@@ -81,7 +81,7 @@
     },
     "NCISOMetadata": {
       "attributes": {
-        "metadata_creation": "2025-03-06",
+        "metadata_creation": "2025-06-25",
         "nciso_version": "2.4.6"
       }
     }
@@ -105,6 +105,9 @@
         "long_name": "latitude in rotated pole grid",
         "standard_name": "grid_latitude",
         "bounds": "rlat_bounds",
+        "_ChunkSizes": [
+          628
+        ],
         "_CoordinateAxisType": "GeoY"
       }
     },
@@ -126,6 +129,9 @@
         "standard_name": "grid_longitude",
         "bounds": "rlon_bounds",
         "units": "degrees",
+        "_ChunkSizes": [
+          655
+        ],
         "_CoordinateAxisType": "GeoX"
       }
     },
@@ -140,6 +146,9 @@
         ],
         "units": "days since 1950-01-01",
         "calendar": "standard",
+        "_ChunkSizes": [
+          512
+        ],
         "_CoordinateAxisType": "Time"
       }
     },
@@ -183,7 +192,12 @@
         ],
         "units": "K",
         "grid_mapping": "crs",
-        "coordinates": "height lat lon"
+        "coordinates": "height lat lon",
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
       }
     },
     "vertices_latitude": {
@@ -197,7 +211,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "vertices_longitude": {
@@ -211,7 +230,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "height": {
@@ -246,6 +270,10 @@
         "long_name": "latitude",
         "units": "degrees_north",
         "bounds": "vertices_latitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lat"
       }
     },
@@ -263,6 +291,10 @@
         "long_name": "longitude",
         "units": "degrees_east",
         "bounds": "vertices_longitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lon"
       }
     }


### PR DESCRIPTION
Couple of bug fixes:
- Lingering `log_debug` option in CORDEX CLI runner
- Fix regression introduced in 0.8.0 in the THREDDSLoader iterator. Suggests a gap in the test suite. 
- Add attributes to the CORDEX ID, otherwise different files will get catalogued under the same ID. 
- Update CORDEX test data to latest version

With those, I'm able to create STAC items for our CORDEX catalog.  

Question: If I wanted to look at the result using your STAC browser, how would I do that?

Note that `test_export` seems to hang when I run it locally. 
