### PR TITLE
Small fixes to create Items out of RDPS and HRDPS data sets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 * Include `PYESSV_ARCHIVE_HOME` environment variable in Dockerfile.
 * Remove redundant CLI arguments.
+* Fix bug in `THREDDSLoader` iterator introduced in 0.8.0. 
+* Remove `log_debug` option from CORDEX-CMIP6_Ouranos' runner. 
+* Add attributes to CORDEX IDs to avoid duplicate IDs in the STAC catalog.
+* Update CORDEX-CMIP6_Ouranos' test data. 
 
 ## [0.8.0](https://github.com/crim-ca/stac-populator/tree/0.8.0) (2025-06-11)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 * Remove `log_debug` option from CORDEX-CMIP6_Ouranos' runner. 
 * Add attributes to CORDEX IDs to avoid duplicate IDs in the STAC catalog.
 * Update CORDEX-CMIP6_Ouranos' test data. 
+* Add default `create_uid` to `THREDDSCatalogDataModel`.
+* Fix bug in `DataCubeHelper` for vertical coordinate extents.
+* Split and clean script to update test data. 
+* Add tests for RDPS and HRDPS attributes with no custom extension. 
 
 ## [0.8.0](https://github.com/crim-ca/stac-populator/tree/0.8.0) (2025-06-11)
 

--- a/STACpopulator/extensions/cordex6.py
+++ b/STACpopulator/extensions/cordex6.py
@@ -65,8 +65,10 @@ class Cordex6DataModel(THREDDSCatalogDataModel):
             "source_id",
             "driving_experiment_id",
             "driving_variant_label",
+            "version_realization",
             "variable_id",
             "domain_id",
+            "frequency",
         ]
         values = [getattr(self.cordex6, k) for k in keys]
         values.append(self.start_datetime.strftime("%Y%m%d"))

--- a/STACpopulator/extensions/datacube.py
+++ b/STACpopulator/extensions/datacube.py
@@ -166,7 +166,7 @@ class DataCubeHelper(Helper):
                                 elif key in ["T", "time"]:
                                     extent = self.temporal_extent()
                                 else:
-                                    extent = ["", ""]
+                                    extent = [None, None]
 
                             properties = dict(
                                 type=type_.value,

--- a/STACpopulator/extensions/thredds.py
+++ b/STACpopulator/extensions/thredds.py
@@ -209,6 +209,13 @@ class THREDDSCatalogDataModel(BaseSTAC):
         data["thredds"] = THREDDSHelper(data["data"]["access_urls"])
         return data
 
+    def create_uid(self) -> str:
+        """Return a unique ID from the server location.
+
+        For datasets with a DRS, it might might more sense to use the dataset's metadata instead."""
+        location = self.data["access_urls"]["HTTPServer"].split("/fileServer/")[1]
+        return location
+
 
 # TODO: Validate services links exist ?
 # @field_validator("access_urls")

--- a/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
+++ b/STACpopulator/implementations/CORDEXCMIP6_Ouranos/add_CORDEX6.py
@@ -57,7 +57,7 @@ def runner(ns: argparse.Namespace, session: Session) -> int:
         data_loader = ErrorLoader()
 
     c = CORDEX_STAC_Populator(
-        ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config, log_debug=ns.debug
+        ns.stac_host, data_loader, update=ns.update, session=session, config_file=ns.config,
     )
     c.ingest()
     return 0

--- a/STACpopulator/input.py
+++ b/STACpopulator/input.py
@@ -103,7 +103,7 @@ class THREDDSLoader(GenericLoader):
                 url = f"{current_catalog.catalog_url}?dataset={dataset.id}"
                 yield item_name, url, attrs
 
-            for ref in current_catalog.catalog_refs:
+            for name, ref in current_catalog.catalog_refs.items():
                 catalogs.put(ref.follow())
 
     def __getitem__(self, dataset: str) -> dict:

--- a/tests/data/cordex6_ncml.json
+++ b/tests/data/cordex6_ncml.json
@@ -88,7 +88,7 @@
     },
     "NCISOMetadata": {
       "attributes": {
-        "metadata_creation": "2025-06-25",
+        "metadata_creation": "2025-07-01",
         "nciso_version": "2.4.6"
       }
     }

--- a/tests/data/cordex6_ncml.json
+++ b/tests/data/cordex6_ncml.json
@@ -39,6 +39,7 @@
     "version_realization": "v1-r1",
     "institution": "Ouranos Consortium on Regional Climatology and Adaptation to Climate Change",
     "NCO": "netCDF Operators version 5.1.8 (Homepage = http://nco.sf.net, Code = http://github.com/nco/nco, Citation = 10.1016/j.envsoft.2008.03.004)",
+    "futher_info_url": "https://zenodo.org/doi/10.5281/zenodo.11061924",
     "abstract": "Ouranos produces operational regional climate simulations over the Cordex North American domain, at 0.11\u00b0 resolution. The current ensemble uses the fifth version of the CRCM, developed at UQAM's ESCER center in collaboration with ECCC. Pilot data for the simulations come from the CMIP6 ensemble, except for those in hindcast mode, which use ERA5.",
     "dataset_id": "CRCM5-CMIP6",
     "license_type": "permissive",
@@ -87,7 +88,7 @@
     },
     "NCISOMetadata": {
       "attributes": {
-        "metadata_creation": "2025-03-06",
+        "metadata_creation": "2025-06-25",
         "nciso_version": "2.4.6"
       }
     }
@@ -111,6 +112,9 @@
         "axis": "Y",
         "standard_name": "grid_latitude",
         "bounds": "rlat_bounds",
+        "_ChunkSizes": [
+          628
+        ],
         "_CoordinateAxisType": "GeoY"
       }
     },
@@ -132,6 +136,9 @@
         "standard_name": "grid_longitude",
         "bounds": "rlon_bounds",
         "units": "degrees",
+        "_ChunkSizes": [
+          655
+        ],
         "_CoordinateAxisType": "GeoX"
       }
     },
@@ -146,6 +153,9 @@
         ],
         "units": "days since 1950-01-01",
         "calendar": "standard",
+        "_ChunkSizes": [
+          512
+        ],
         "_CoordinateAxisType": "Time"
       }
     },
@@ -180,7 +190,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "vertices_longitude": {
@@ -194,7 +209,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "tas": {
@@ -217,7 +237,12 @@
         ],
         "units": "K",
         "grid_mapping": "crs",
-        "coordinates": "height lat lon"
+        "coordinates": "height lat lon",
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
       }
     },
     "pr": {
@@ -240,7 +265,12 @@
         ],
         "units": "kg m-2 s-1",
         "grid_mapping": "crs",
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
       }
     },
     "time_bnds": {
@@ -252,6 +282,90 @@
       "attributes": {
         "_FillValue": [
           NaN
+        ],
+        "_ChunkSizes": [
+          1,
+          2
+        ]
+      }
+    },
+    "quantization_info": {
+      "shape": [
+        ""
+      ],
+      "type": "char",
+      "attributes": {
+        "algorithm": "bitround",
+        "implementation": "NCO version 5.3.2"
+      }
+    },
+    "prsn": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "Snowfall Flux",
+        "_FillValue": [
+          1.0000000200408773e+20
+        ],
+        "standard_name": "snowfall_flux",
+        "cell_measures": "area: areacella",
+        "cell_methods": "area: time: mean",
+        "missing_value": [
+          1.0000000200408773e+20
+        ],
+        "units": "kg m-2 s-1",
+        "grid_mapping": "crs",
+        "coordinates": "lat lon",
+        "quantization": "quantization_info",
+        "quantization_nsb": [
+          12
+        ],
+        "quantization_maximum_relative_error": [
+          0.0001220703125
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
+      }
+    },
+    "snw": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "Surface Snow Amount",
+        "_FillValue": [
+          1.0000000200408773e+20
+        ],
+        "standard_name": "surface_snow_amount",
+        "cell_measures": "area: areacella",
+        "cell_methods": "area: mean where land time: point",
+        "missing_value": [
+          1.0000000200408773e+20
+        ],
+        "units": "kg m-2",
+        "grid_mapping": "crs",
+        "coordinates": "lat lon",
+        "quantization": "quantization_info",
+        "quantization_nsb": [
+          12
+        ],
+        "quantization_maximum_relative_error": [
+          0.0001220703125
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
         ]
       }
     },
@@ -275,6 +389,11 @@
         "coordinates": "height lat lon",
         "missing_value": [
           1.0000000200408773e+20
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
         ]
       }
     },
@@ -298,6 +417,11 @@
         "coordinates": "height lat lon",
         "missing_value": [
           1.0000000200408773e+20
+        ],
+        "_ChunkSizes": [
+          250,
+          50,
+          50
         ]
       }
     },
@@ -333,6 +457,10 @@
         "standard_name": "latitude",
         "units": "degrees_north",
         "bounds": "vertices_latitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lat"
       }
     },
@@ -350,6 +478,10 @@
         "standard_name": "longitude",
         "units": "degrees_east",
         "bounds": "vertices_longitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lon"
       }
     }

--- a/tests/data/cordex6_raw.json
+++ b/tests/data/cordex6_raw.json
@@ -81,7 +81,7 @@
     },
     "NCISOMetadata": {
       "attributes": {
-        "metadata_creation": "2025-06-25",
+        "metadata_creation": "2025-07-01",
         "nciso_version": "2.4.6"
       }
     }

--- a/tests/data/cordex6_raw.json
+++ b/tests/data/cordex6_raw.json
@@ -81,7 +81,7 @@
     },
     "NCISOMetadata": {
       "attributes": {
-        "metadata_creation": "2025-03-06",
+        "metadata_creation": "2025-06-25",
         "nciso_version": "2.4.6"
       }
     }
@@ -105,6 +105,9 @@
         "long_name": "latitude in rotated pole grid",
         "standard_name": "grid_latitude",
         "bounds": "rlat_bounds",
+        "_ChunkSizes": [
+          628
+        ],
         "_CoordinateAxisType": "GeoY"
       }
     },
@@ -126,6 +129,9 @@
         "standard_name": "grid_longitude",
         "bounds": "rlon_bounds",
         "units": "degrees",
+        "_ChunkSizes": [
+          655
+        ],
         "_CoordinateAxisType": "GeoX"
       }
     },
@@ -140,6 +146,9 @@
         ],
         "units": "days since 1950-01-01",
         "calendar": "standard",
+        "_ChunkSizes": [
+          512
+        ],
         "_CoordinateAxisType": "Time"
       }
     },
@@ -183,7 +192,12 @@
         ],
         "units": "K",
         "grid_mapping": "crs",
-        "coordinates": "height lat lon"
+        "coordinates": "height lat lon",
+        "_ChunkSizes": [
+          250,
+          50,
+          50
+        ]
       }
     },
     "vertices_latitude": {
@@ -197,7 +211,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "vertices_longitude": {
@@ -211,7 +230,12 @@
         "_FillValue": [
           NaN
         ],
-        "coordinates": "lat lon"
+        "coordinates": "lat lon",
+        "_ChunkSizes": [
+          628,
+          655,
+          2
+        ]
       }
     },
     "height": {
@@ -246,6 +270,10 @@
         "long_name": "latitude",
         "units": "degrees_north",
         "bounds": "vertices_latitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lat"
       }
     },
@@ -263,6 +291,10 @@
         "long_name": "longitude",
         "units": "degrees_east",
         "bounds": "vertices_longitude",
+        "_ChunkSizes": [
+          628,
+          655
+        ],
         "_CoordinateAxisType": "Lon"
       }
     }

--- a/tests/data/hrdps_p_tt.json
+++ b/tests/data/hrdps_p_tt.json
@@ -1,0 +1,197 @@
+{
+  "@location": "Not provided because of security concerns.",
+  "@xmlns": {
+    "": "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+  },
+  "attributes": {
+    "_NCProperties": "version=2,netcdf=4.9.2,hdf5=1.14.2",
+    "Remarks": "Variable names are following the convention <Product>_<Type:A=Analysis,P=Prediction>_<ECCC name>_<Level/Tile/Category>. Variables with level '10000' are at surface level. The height [m] of variables with level '0XXXX' needs to be inferrred using the corresponding fields of geopotential height (GZ_0XXXX-GZ_10000). The variables UUC, VVC, UVC, and WDC are not modelled but inferred from UU and VV for convenience of the users. Precipitation (PR) is reported as 6-hr accumulations for CaPA_fine and CaPA_coarse. Precipitation (PR) are accumulations since beginning of the forecast for GEPS, GDPS, REPS, RDPS, HRDPS, and CaLDAS. The re-analysis product RDRS_v2 contains two variables for precipitation: 'RDRS_v2_P_PR0_SFC' is the model precipitation (trial field used by CaPA) and 'RDRS_v2_A_PR0_SFC' is precipitations adjusted with CaPA 24h precipitation (as in 'RDRS_P_PR0_SFC'). Please be aware that the baseflow 'O1' of the current version of WCPS is not reliable during the spring melt period.",
+    "License": "These data are provided by the Canadian Surface Prediction Archive CaSPar. You should have received a copy of the License agreement with the data. Otherwise you can find them under http://caspar-data.ca/doc/caspar_license.txt or email caspar.data@uwaterloo.ca.",
+    "product": "HRDPS",
+    "Conventions": "CF-1.6",
+    "_CoordSysBuilder": "ucar.nc2.internal.dataset.conv.CF1Convention"
+  },
+  "dimensions": {
+    "rlon": 2540,
+    "rlat": 1290,
+    "time": 13
+  },
+  "groups": {
+    "CFMetadata": {
+      "attributes": {
+        "geospatial_lon_min": [
+          -152.7306365966797
+        ],
+        "geospatial_lat_min": [
+          27.284589767456055
+        ],
+        "geospatial_lon_max": [
+          -40.708560943603516
+        ],
+        "geospatial_lat_max": [
+          70.61150360107422
+        ],
+        "geospatial_lon_units": "degrees_east",
+        "geospatial_lat_units": "degrees_north",
+        "geospatial_lon_resolution": "3.418852275416474E-5",
+        "geospatial_lat_resolution": "1.3223137054096467E-5",
+        "time_coverage_start": "2024-01-01T00:00:00Z",
+        "time_coverage_end": "2024-01-01T12:00:00Z",
+        "time_coverage_units": "seconds",
+        "time_coverage_resolution": "3600.0",
+        "time_coverage_duration": "P0Y0M0DT12H0M0.000S"
+      }
+    },
+    "NCISOMetadata": {
+      "attributes": {
+        "metadata_creation": "2025-07-01",
+        "nciso_version": "2.4.6"
+      }
+    }
+  },
+  "variables": {
+    "rlon": {
+      "shape": [
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "longitude in rotated pole grid",
+        "units": "degrees",
+        "eccc_grid_definition": "grtyp: E, ig1: 1430, ig2: 500, ig3: 56000, ig4: 44000",
+        "standard_name": "grid_longitude",
+        "axis": "X",
+        "_ChunkSizes": [
+          2540
+        ],
+        "_CoordinateAxisType": "GeoX"
+      }
+    },
+    "rlat": {
+      "shape": [
+        "rlat"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "latitude in rotated pole grid",
+        "units": "degrees",
+        "eccc_grid_definition": "grtyp: E, ig1: 1430, ig2: 500, ig3: 56000, ig4: 44000",
+        "standard_name": "grid_latitude",
+        "axis": "Y",
+        "_ChunkSizes": [
+          1290
+        ],
+        "_CoordinateAxisType": "GeoY"
+      }
+    },
+    "time": {
+      "shape": [
+        "time"
+      ],
+      "type": "int",
+      "attributes": {
+        "long_name": "time",
+        "units": "hours since 2024-01-01 00:00:00",
+        "calendar": "gregorian",
+        "standard_name": "time",
+        "axis": "T",
+        "_ChunkSizes": [
+          1024
+        ],
+        "_CoordinateAxisType": "Time"
+      }
+    },
+    "HRDPS_P_TT_10000": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "Forecast: Air temperature",
+        "units": "deg_C",
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1290,
+          2540
+        ]
+      }
+    },
+    "rotated_pole": {
+      "shape": [
+        ""
+      ],
+      "type": "float",
+      "attributes": {
+        "grid_north_pole_longitude": [
+          65.3051528930664
+        ],
+        "north_pole_grid_longitude": [
+          0.0
+        ],
+        "longitude_of_prime_meridian": [
+          0.0
+        ],
+        "grid_north_pole_latitude": [
+          36.088523864746094
+        ],
+        "earth_radius": [
+          6371220.0
+        ],
+        "long_name": "coordinates of the rotated North Pole",
+        "grid_mapping_name": "rotated_latitude_longitude",
+        "_CoordinateTransformType": "Projection",
+        "_CoordinateAxisTypes": "GeoX GeoY"
+      }
+    },
+    "lon": {
+      "shape": [
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "longitude",
+        "units": "degrees_east",
+        "eccc_grid_definition": "grtyp: Z, ig1: 76826, ig2: 74520, ig3: 1, ig4: 0",
+        "standard_name": "longitude",
+        "_ChunkSizes": [
+          1290,
+          2540
+        ],
+        "_CoordinateAxisType": "Lon"
+      }
+    },
+    "lat": {
+      "shape": [
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "latitude",
+        "units": "degrees_north",
+        "eccc_grid_definition": "grtyp: Z, ig1: 76826, ig2: 74520, ig3: 1, ig4: 0",
+        "standard_name": "latitude",
+        "_ChunkSizes": [
+          1290,
+          2540
+        ],
+        "_CoordinateAxisType": "Lat"
+      }
+    }
+  },
+  "access_urls": {
+    "HTTPServer": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc",
+    "OpenDAP": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc",
+    "NCML": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncml/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc",
+    "UDDC": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/uddc/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc",
+    "ISO": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/iso/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc",
+    "WCS": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wcs/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc",
+    "WMS": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wms/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc",
+    "NetcdfSubset": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncss/point/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/2024010100.nc"
+  }
+}

--- a/tests/data/hrdps_sfc.json
+++ b/tests/data/hrdps_sfc.json
@@ -1,0 +1,197 @@
+{
+  "@location": "Not provided because of security concerns.",
+  "@xmlns": {
+    "": "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+  },
+  "attributes": {
+    "_NCProperties": "version=2,netcdf=4.9.2,hdf5=1.14.2",
+    "Remarks": "Variable names are following the convention <Product>_<Type:A=Analysis,P=Prediction>_<ECCC name>_<Level/Tile/Category>. Variables with level '10000' are at surface level. The height [m] of variables with level '0XXXX' needs to be inferrred using the corresponding fields of geopotential height (GZ_0XXXX-GZ_10000). The variables UUC, VVC, UVC, and WDC are not modelled but inferred from UU and VV for convenience of the users. Precipitation (PR) is reported as 6-hr accumulations for CaPA_fine and CaPA_coarse. Precipitation (PR) are accumulations since beginning of the forecast for GEPS, GDPS, REPS, RDPS, HRDPS, and CaLDAS. The re-analysis product RDRS_v2 contains two variables for precipitation: 'RDRS_v2_P_PR0_SFC' is the model precipitation (trial field used by CaPA) and 'RDRS_v2_A_PR0_SFC' is precipitations adjusted with CaPA 24h precipitation (as in 'RDRS_P_PR0_SFC'). Please be aware that the baseflow 'O1' of the current version of WCPS is not reliable during the spring melt period.",
+    "License": "These data are provided by the Canadian Surface Prediction Archive CaSPar. You should have received a copy of the License agreement with the data. Otherwise you can find them under http://caspar-data.ca/doc/caspar_license.txt or email caspar.data@uwaterloo.ca.",
+    "product": "HRDPS",
+    "Conventions": "CF-1.6",
+    "_CoordSysBuilder": "ucar.nc2.internal.dataset.conv.CF1Convention"
+  },
+  "dimensions": {
+    "rlon": 2540,
+    "rlat": 1290,
+    "time": 13
+  },
+  "groups": {
+    "CFMetadata": {
+      "attributes": {
+        "geospatial_lon_min": [
+          -152.7306365966797
+        ],
+        "geospatial_lat_min": [
+          27.284589767456055
+        ],
+        "geospatial_lon_max": [
+          -40.708560943603516
+        ],
+        "geospatial_lat_max": [
+          70.61150360107422
+        ],
+        "geospatial_lon_units": "degrees_east",
+        "geospatial_lat_units": "degrees_north",
+        "geospatial_lon_resolution": "3.418852275416474E-5",
+        "geospatial_lat_resolution": "1.3223137054096467E-5",
+        "time_coverage_start": "2024-01-01T00:00:00Z",
+        "time_coverage_end": "2024-01-01T12:00:00Z",
+        "time_coverage_units": "seconds",
+        "time_coverage_resolution": "3600.0",
+        "time_coverage_duration": "P0Y0M0DT12H0M0.000S"
+      }
+    },
+    "NCISOMetadata": {
+      "attributes": {
+        "metadata_creation": "2025-07-01",
+        "nciso_version": "2.4.6"
+      }
+    }
+  },
+  "variables": {
+    "rlon": {
+      "shape": [
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "longitude in rotated pole grid",
+        "units": "degrees",
+        "eccc_grid_definition": "grtyp: E, ig1: 1430, ig2: 500, ig3: 56000, ig4: 44000",
+        "standard_name": "grid_longitude",
+        "axis": "X",
+        "_ChunkSizes": [
+          2540
+        ],
+        "_CoordinateAxisType": "GeoX"
+      }
+    },
+    "rlat": {
+      "shape": [
+        "rlat"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "latitude in rotated pole grid",
+        "units": "degrees",
+        "eccc_grid_definition": "grtyp: E, ig1: 1430, ig2: 500, ig3: 56000, ig4: 44000",
+        "standard_name": "grid_latitude",
+        "axis": "Y",
+        "_ChunkSizes": [
+          1290
+        ],
+        "_CoordinateAxisType": "GeoY"
+      }
+    },
+    "time": {
+      "shape": [
+        "time"
+      ],
+      "type": "int",
+      "attributes": {
+        "long_name": "time",
+        "units": "hours since 2024-01-01 00:00:00",
+        "calendar": "gregorian",
+        "standard_name": "time",
+        "axis": "T",
+        "_ChunkSizes": [
+          1024
+        ],
+        "_CoordinateAxisType": "Time"
+      }
+    },
+    "HRDPS_P_PR_SFC": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "Forecast: Quantity of precipitation",
+        "units": "m",
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1290,
+          2540
+        ]
+      }
+    },
+    "rotated_pole": {
+      "shape": [
+        ""
+      ],
+      "type": "float",
+      "attributes": {
+        "grid_north_pole_longitude": [
+          65.3051528930664
+        ],
+        "north_pole_grid_longitude": [
+          0.0
+        ],
+        "longitude_of_prime_meridian": [
+          0.0
+        ],
+        "grid_north_pole_latitude": [
+          36.088523864746094
+        ],
+        "earth_radius": [
+          6371220.0
+        ],
+        "long_name": "coordinates of the rotated North Pole",
+        "grid_mapping_name": "rotated_latitude_longitude",
+        "_CoordinateTransformType": "Projection",
+        "_CoordinateAxisTypes": "GeoX GeoY"
+      }
+    },
+    "lon": {
+      "shape": [
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "longitude",
+        "units": "degrees_east",
+        "eccc_grid_definition": "grtyp: Z, ig1: 76826, ig2: 74520, ig3: 1, ig4: 0",
+        "standard_name": "longitude",
+        "_ChunkSizes": [
+          1290,
+          2540
+        ],
+        "_CoordinateAxisType": "Lon"
+      }
+    },
+    "lat": {
+      "shape": [
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "latitude",
+        "units": "degrees_north",
+        "eccc_grid_definition": "grtyp: Z, ig1: 76826, ig2: 74520, ig3: 1, ig4: 0",
+        "standard_name": "latitude",
+        "_ChunkSizes": [
+          1290,
+          2540
+        ],
+        "_CoordinateAxisType": "Lat"
+      }
+    }
+  },
+  "access_urls": {
+    "HTTPServer": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc",
+    "OpenDAP": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc",
+    "NCML": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncml/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc",
+    "UDDC": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/uddc/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc",
+    "ISO": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/iso/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc",
+    "WCS": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wcs/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc",
+    "WMS": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wms/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc",
+    "NetcdfSubset": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncss/point/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_PR_SFC/2024010100.nc"
+  }
+}

--- a/tests/data/rdps.json
+++ b/tests/data/rdps.json
@@ -1,0 +1,489 @@
+{
+  "@location": "Not provided because of security concerns.",
+  "@xmlns": {
+    "": "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+  },
+  "attributes": {
+    "Conventions": "CF-1.6",
+    "_NCProperties": "version=2,netcdf=4.9.2,hdf5=1.14.2",
+    "_CoordSysBuilder": "ucar.nc2.internal.dataset.conv.CF1Convention"
+  },
+  "dimensions": {
+    "pres": 4,
+    "rlat": 1076,
+    "rlon": 1102
+  },
+  "groups": {
+    "CFMetadata": {
+      "attributes": {
+        "geospatial_lon_min": [
+          0.0002899999963119626
+        ],
+        "geospatial_lat_min": [
+          -7.749110221862793
+        ],
+        "geospatial_lon_max": [
+          359.99951171875
+        ],
+        "geospatial_lat_max": [
+          89.96572875976562
+        ],
+        "geospatial_lon_units": "degrees_east",
+        "geospatial_lat_units": "degrees_north",
+        "geospatial_lon_resolution": "3.036044005049318E-4",
+        "geospatial_lat_resolution": "8.240755029254131E-5",
+        "time_coverage_start": "2024-01-01T00:00:00Z",
+        "time_coverage_end": "2024-01-01T00:00:00Z",
+        "time_coverage_units": "seconds",
+        "time_coverage_resolution": "0.0",
+        "time_coverage_duration": "P0Y0M0DT0H0M0.000S"
+      }
+    },
+    "NCISOMetadata": {
+      "attributes": {
+        "metadata_creation": "2025-07-01",
+        "nciso_version": "2.4.6"
+      }
+    }
+  },
+  "variables": {
+    "time": {
+      "shape": [
+        "time"
+      ],
+      "type": "double",
+      "attributes": {
+        "standard_name": "time",
+        "long_name": "Validity time",
+        "axis": "T",
+        "units": "hours since 2024-01-01 00:00:00",
+        "calendar": "gregorian",
+        "_ChunkSizes": [
+          512
+        ],
+        "_CoordinateAxisType": "Time"
+      }
+    },
+    "pres": {
+      "shape": [
+        "pres"
+      ],
+      "type": "float",
+      "attributes": {
+        "axis": "Z",
+        "standard_name": "air_pressure",
+        "units": "hPa",
+        "positive": "down",
+        "_CoordinateAxisType": "Pressure",
+        "_CoordinateZisPositive": "down"
+      }
+    },
+    "rlat": {
+      "shape": [
+        "rlat"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "latitude in rotated pole grid",
+        "standard_name": "grid_latitude",
+        "units": "degrees",
+        "axis": "Y",
+        "_CoordinateAxisType": "GeoY"
+      }
+    },
+    "rlon": {
+      "shape": [
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "longitude in rotated pole grid",
+        "standard_name": "grid_longitude",
+        "units": "degrees",
+        "axis": "X",
+        "_CoordinateAxisType": "GeoX"
+      }
+    },
+    "level": {
+      "shape": [
+        "level"
+      ],
+      "type": "float",
+      "attributes": {
+        "axis": "Z",
+        "positive": "down",
+        "standard_name": "atmosphere_hybrid_sigma_ln_pressure_coordinate",
+        "formula": "p = exp(a+b*log(ps/pref)) / 100.0",
+        "formula_terms": "a: a b: b ps: P0 pref: pref",
+        "coordinates": "a b",
+        "_CoordinateAxisType": "GeoZ",
+        "_CoordinateZisPositive": "down"
+      }
+    },
+    "GZ": {
+      "shape": [
+        "time",
+        "pres",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "rotated_pole": {
+      "shape": [
+        ""
+      ],
+      "type": "char",
+      "attributes": {
+        "grid_mapping_name": "rotated_latitude_longitude",
+        "earth_radius": [
+          6370997.0
+        ],
+        "grid_north_pole_latitude": [
+          31.758312454493154
+        ],
+        "grid_north_pole_longitude": [
+          87.59703130293302
+        ],
+        "north_pole_grid_longitude": [
+          0.0
+        ],
+        "_CoordinateTransformType": "Projection",
+        "_CoordinateAxisTypes": "GeoX GeoY"
+      }
+    },
+    "HU": {
+      "shape": [
+        "time",
+        "pres",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "grid_mapping": "rotated_pole",
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "PC": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "PN": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "PR": {
+      "shape": [
+        "time",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "TD": {
+      "shape": [
+        "time",
+        "level",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "pref": {
+      "shape": [
+        ""
+      ],
+      "type": "double",
+      "attributes": {
+        "units": "hPa"
+      }
+    },
+    "TT_pressure_levels": {
+      "shape": [
+        "time",
+        "pres",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "TT_model_levels": {
+      "shape": [
+        "time",
+        "level",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "UU_pressure_levels": {
+      "shape": [
+        "time",
+        "pres",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "UU_model_levels": {
+      "shape": [
+        "time",
+        "level",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "VV_pressure_levels": {
+      "shape": [
+        "time",
+        "pres",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "VV_model_levels": {
+      "shape": [
+        "time",
+        "level",
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "_FillValue": [
+          1.0000000150474662e+30
+        ],
+        "coordinates": "lon lat",
+        "grid_mapping": "rotated_pole",
+        "_ChunkSizes": [
+          1,
+          1,
+          1076,
+          1102
+        ]
+      }
+    },
+    "leadtime": {
+      "shape": [
+        "time"
+      ],
+      "type": "float",
+      "attributes": {
+        "standard_name": "forecast_period",
+        "long_name": "Lead time (since forecast_reference_time)",
+        "units": "hours",
+        "_ChunkSizes": [
+          1024
+        ],
+        "_CoordinateAxisType": "TimeOffset"
+      }
+    },
+    "reftime": {
+      "shape": [
+        ""
+      ],
+      "type": "double",
+      "attributes": {
+        "standard_name": "forecast_reference_time",
+        "units": "hours since 2024-01-01 00:00:00",
+        "calendar": "gregorian",
+        "_CoordinateAxisType": "RunTime"
+      }
+    },
+    "lon": {
+      "shape": [
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "units": "degrees_east",
+        "standard_name": "longitude",
+        "long_name": "longitude",
+        "_CoordinateAxisType": "Lon"
+      }
+    },
+    "lat": {
+      "shape": [
+        "rlat",
+        "rlon"
+      ],
+      "type": "float",
+      "attributes": {
+        "long_name": "latitude",
+        "standard_name": "latitude",
+        "units": "degrees_north",
+        "_CoordinateAxisType": "Lat"
+      }
+    },
+    "a": {
+      "shape": [
+        "level"
+      ],
+      "type": "double"
+    },
+    "b": {
+      "shape": [
+        "level"
+      ],
+      "type": "double"
+    }
+  },
+  "access_urls": {
+    "HTTPServer": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc",
+    "OpenDAP": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc",
+    "NCML": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncml/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc",
+    "UDDC": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/uddc/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc",
+    "ISO": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/iso/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc",
+    "WCS": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wcs/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc",
+    "WMS": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/wms/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc",
+    "NetcdfSubset": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/ncss/point/birdhouse/testdata/HRDPS/RDPS_sample/2024010100_000.nc"
+  }
+}

--- a/tests/data/update_data.py
+++ b/tests/data/update_data.py
@@ -1,0 +1,42 @@
+import json
+import requests
+import xncml
+from siphon.catalog import TDSCatalog
+
+from STACpopulator.stac_utils import np2py
+
+
+def get_first_item_attrs(url):
+    cat = TDSCatalog(url)
+
+    if cat.datasets.items():
+        for item_name, ds in cat.datasets.items():
+            r = requests.get(ds.access_urls["NCML"])
+            attrs = xncml.Dataset.from_text(r.text).to_cf_dict()
+            attrs["access_urls"] = ds.access_urls
+            return np2py(attrs)
+
+
+def make_test_data():
+    """Fetches attribute data from the PAVICS THREDDS catalog and stores it in the data/ directory as a json."""
+    # Mapping between test data file names and URLs
+    urls = {
+        "cordex6_raw.json": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/disk2/ouranos/CORDEX/CMIP6/DD/NAM-12/OURANOS/MPI-ESM1-2-LR/ssp370/r1i1p1f1/CRCM5/v1-r1/day/tas/v20231208/catalog.html",
+        "cordex6_ncml.json": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/simulations"
+                             "/RCM-CMIP6/CORDEX/NAM-12/day/catalog.html",
+        "rdps.json": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/HRDPS"
+                     "/RDPS_sample/catalog.html",
+        "hrdps_sfc.json": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/HRDPS"
+                          "/HRDPS_sample/HRDPS_P_PR_SFC/catalog.html",
+        "hrdps_p_tt.json": "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/HRDPS/HRDPS_sample/HRDPS_P_TT_10000/catalog.html"}
+
+    for filename, url in urls.items():
+        attrs = get_first_item_attrs(url)
+        with open(filename, "w") as f:
+            json.dump(attrs, f, indent=2)
+
+
+if __name__ == "__main__":
+    make_test_data()
+    print("Test data files created in the current directory.")
+

--- a/tests/test_cordex.py
+++ b/tests/test_cordex.py
@@ -1,38 +1,5 @@
-import json
-
 from STACpopulator.extensions.cordex6 import Cordex6DataModel, Cordex6DataModelNcML
-
-
-def get_first_item_attrs(url):
-    import requests
-    import xncml
-    from siphon.catalog import TDSCatalog
-
-    from STACpopulator.stac_utils import np2py
-
-    cat = TDSCatalog(url)
-
-    if cat.datasets.items():
-        for item_name, ds in cat.datasets.items():
-            r = requests.get(ds.access_urls["NCML"])
-            attrs = xncml.Dataset.from_text(r.text).to_cf_dict()
-            attrs["access_urls"] = ds.access_urls
-            return np2py(attrs)
-
-
-def make_test_data():
-    """Fetches attribute data from the PAVICS THREDDS catalog and stores it in the data/ directory as a json."""
-    # Raw CORDEX data
-    url = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/disk2/ouranos/CORDEX/CMIP6/DD/NAM-12/OURANOS/MPI-ESM1-2-LR/ssp370/r1i1p1f1/CRCM5/v1-r1/day/tas/v20231208/catalog.html"
-    attrs = get_first_item_attrs(url)
-    with open("data/cordex6_raw.json", "w") as f:
-        json.dump(attrs, f, indent=2)
-
-    # NcML CORDEX data
-    url = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/simulations/RCM-CMIP6/CORDEX/NAM-12/day/catalog.html"
-    attrs = get_first_item_attrs(url)
-    with open("data/cordex6_ncml.json", "w") as f:
-        json.dump(attrs, f, indent=2)
+import json
 
 
 def test_item_raw():

--- a/tests/test_rdps.py
+++ b/tests/test_rdps.py
@@ -1,0 +1,21 @@
+"""Test RDPS and HRDPS netCDF files."""
+import json
+from STACpopulator.extensions.thredds import THREDDSCatalogDataModel
+
+def test_rdps():
+    attrs = json.load(open("tests/data/rdps.json"))
+    model = THREDDSCatalogDataModel.from_data(attrs)
+    item = model.stac_item()
+    assert set(model._helpers) == {"thredds", "datacube"}
+
+
+def test_hrdps():
+    attrs = json.load(open("tests/data/hrdps_sfc.json"))
+    model = THREDDSCatalogDataModel.from_data(attrs)
+    item = model.stac_item()
+    assert set(model._helpers) == {"thredds", "datacube"}
+
+    attrs = json.load(open("tests/data/hrdps_p_tt.json"))
+    model = THREDDSCatalogDataModel.from_data(attrs)
+    item = model.stac_item()
+    assert set(model._helpers) == {"thredds", "datacube"}


### PR DESCRIPTION
RDPS and HRDPS are the datasets used to train the spatial downscaling U-Net in the GeoConnexions project. 

There are small test samples here:
https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/HRDPS/catalog.html

This PR runs STAC item creation tests against those datasets. The only fixes needed to run the tests were
1. Add a default `create_uid` method in the THREDDSCatalogDataModel. Not doing so would mean having to create a custom extension for every dataset we want to add to the catalog. The default UID is just the location of the dataset relative to the `fileserver/` URL. 
2. Change how empty vertical spatial extents are encoded to match the schema. Previously `[", "]`, now `[None, None]`. 

## Notes

In the DataCube 2.2.0 schema, the `vertical_spatial_dimension` has a required `extent` defined as 
```json
extent_open": {
      "type": "array",
      "minItems": 2,
      "maxItems": 2,
      "items": {
        "type": [
          "number",
          "null"
        ]
      }
    }
```

