### PR TITLE
fix dependabot resolution issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,9 +193,8 @@ dev = [
     "responses~=0.25",
     "bump-my-version~=1.0",
     "jsonschema~=4.23",
-    "pystac[validation]~=1.13.0",
+    "pystac[validation]",
     "ruff~=0.9",
     "pre-commit~=4.1",
     "pytest-recording~=0.13"
 ]
-


### PR DESCRIPTION
Dependabot doesn't seem to want to update both versions of pystac (in pyproject.toml) simultaneously. 

- #110
- #112 

The recommended way to resolve this is to set the version of pystac that we want in the `dependencies` and then not to define a specific version in `project-optional-dependencies` where we specify that the `[validation]` optional dependencies are required. 

This will ensure that the pystac version we want is only declared in one place and dependabot will be able to update this properly.

Closes #112 

This should be merged before #110 so that the tests for that PR will run properly. 