### PR TITLE
add precommit repos to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot does not currently update pre-commit repository versions. This change adds that ability to dependabot.