### PR TITLE
add filtered collection ID export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased](https://github.com/crim-ca/stac-populator) (latest)
 
-<!-- insert list items of new changes here -->
+* Add `-c`/`--collection` option to `export` operation to filter which collections should be exported,
+  rather than the entire catalog. The value can be the plain Collection ID or a regex pattern.
 
 ## [0.14.0](https://github.com/crim-ca/stac-populator/tree/0.14.0) (2026-04-13)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 * Add `-c`/`--collection` option to `export` operation to filter which collections should be exported,
   rather than the entire catalog. The value can be the plain Collection ID or a regex pattern.
+* Add explicit log entries of processed or skipped Catalogs/Collections
+  (fixes [#101](https://github.com/crim-ca/stac-populator/issues/101)).
+* Fix `export` target directory parent(s) creation if missing.
 
 ## [0.14.0](https://github.com/crim-ca/stac-populator/tree/0.14.0) (2026-04-13)
 
@@ -15,13 +18,13 @@
 ## [0.13.0](https://github.com/crim-ca/stac-populator/tree/0.13.0) (2026-01-29)
 
 * Simplify populator implementation discovery and reduce boilerplate for new implementations.
-* Add a classmethod to add additional CLI args to the `STACpopulatorBase` class (replaces `add_parser_args`)
-* Add a classmethod to run the populator based on CLI args to the `STACpopulatorBase` class (replaces `runner`)
-* Add shared implementations for these two classmethods to a `THREDDSpopulatorBase` class that can be
+* Add a `classmethod` to add additional CLI args to the `STACpopulatorBase` class (replaces `add_parser_args`)
+* Add a `classmethod` to run the populator based on CLI args to the `STACpopulatorBase` class (replaces `runner`)
+* Add shared implementations for these two `classmethod` to a `THREDDSpopulatorBase` class that can be
   used by all populators that pull data from THREDDS
 * Rename `populator_base.py` to `populators.py` since it now contains more than just the base populator
 * No longer require new implementations to list populator modules in `implementations.__init__.py`
-* Implementation discovery is now done by keeping track of concrete implementations of the STACpopulatorBase class
+* Implementation discovery is now done by keeping track of concrete implementations of the `STACpopulatorBase` class
 
 ## [0.12.0](https://github.com/crim-ca/stac-populator/tree/0.12.0) (2025-11-20)
 
@@ -29,7 +32,7 @@
 * Add `RDPS_CRIM` and `HRDPS_CRIM` implementations.
 * Add `cf` extension adding CF Parameter metadata to (H)RDPS stac asset and items.
 * Add `cf` and `file` helpers.
-* Add `providers` and `contacts` extensions metdata to (H)RDPS stac collection.
+* Add `providers` and `contacts` extensions metadata to (H)RDPS stac collection.
 * Fix deprecated access to `model_fields` in `BaseSTAC` data model class.
 * Fix bug service type check in extensions' `get_assets` methods.
 * Fix return type of `from_data` in `THREDDSCatalogDataModel`.

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -72,15 +72,22 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
     export_parser.add_argument(
         "--ignore-duplicate-ids",
         action="store_true",
-        help="Do not raise an error if STAC items with the same ids are found in a collection.",
+        help="Do not raise an error if STAC Items with the same IDs are found in a collection.",
+    )
+    export_parser.add_argument(
+        "--collection-ignore-duplicate-ids",
+        action="store_true",
+        help="Do not raise an error if STAC Collections with the same IDs are found catalog(s).",
     )
     export_parser.add_argument(
         "-c",
         "--collection",
         nargs="*",
         help=(
-            "Only export collections whose ID matches the regex pattern. "
-            "A plain ID without pattern will only match the exact collection."
+            "Only export collections whose ID matches the entire regex pattern. "
+            "A plain ID without pattern will only match the exact collection. "
+            "If a search pattern is needed, employ adequate regexes as needed. "
+            "Multiple collection IDs can be provided. "
         ),
     )
 
@@ -125,6 +132,7 @@ def run(ns: argparse.Namespace) -> int:
                     session,
                     ns.resume,
                     ns.ignore_duplicate_ids,
+                    ns.collection_ignore_duplicate_ids,
                     ns.collection,
                 )
                 or 0

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -74,6 +74,11 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Do not raise an error if STAC items with the same ids are found in a collection.",
     )
+    export_parser.add_argument(
+        "-c", "--collection",
+        type=str,
+        help="Specific ID or regex pattern for which to filter matched collections from the catalog(s).",
+    )
 
 
 @functools.cache
@@ -109,7 +114,14 @@ def run(ns: argparse.Namespace) -> int:
         elif ns.command == "update_collection":
             return update_api_collection(ns.mode, ns.stac_collection_uri, ns.exclude_summary) or 0
         else:
-            return export_catalog(ns.directory, ns.stac_host, session, ns.resume, ns.ignore_duplicate_ids) or 0
+            return export_catalog(
+                ns.directory,
+                ns.stac_host,
+                session,
+                ns.resume,
+                ns.ignore_duplicate_ids,
+                ns.collection,
+            ) or 0
 
 
 def main(*args: str) -> int:

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -77,6 +77,7 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
     export_parser.add_argument(
         "-c",
         "--collection",
+        nargs="*",
         help=(
             "Only export collections whose ID matches the regex pattern. "
             "A plain ID without pattern will only match the exact collection."

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -67,7 +67,7 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
     )
     export_parser = commands_subparser.add_parser("export", description="Export a STAC catalog to JSON files on disk.")
     export_parser.add_argument("stac_host", help="STAC API URL")
-    export_parser.add_argument("directory", type=str, help="Path to a directory to write STAC catalog contents.")
+    export_parser.add_argument("directory", help="Path to a directory to write STAC catalog contents.")
     export_parser.add_argument("-r", "--resume", action="store_true", help="Resume a partial download.")
     export_parser.add_argument(
         "--ignore-duplicate-ids",
@@ -77,8 +77,10 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
     export_parser.add_argument(
         "-c",
         "--collection",
-        type=str,
-        help="Specific ID or regex pattern for which to filter matched collections from the catalog(s).",
+        help=(
+            "Only export collections whose ID matches the regex pattern. "
+            "A plain ID without pattern will only match the exact collection."
+        ),
     )
 
 

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -77,7 +77,7 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
     export_parser.add_argument(
         "--collection-ignore-duplicate-ids",
         action="store_true",
-        help="Do not raise an error if STAC Collections with the same IDs are found catalog(s).",
+        help="Do not raise an error if STAC Collections with the same IDs are found in catalog(s).",
     )
     export_parser.add_argument(
         "-c",

--- a/STACpopulator/cli.py
+++ b/STACpopulator/cli.py
@@ -75,7 +75,8 @@ def add_parser_args(parser: argparse.ArgumentParser) -> None:
         help="Do not raise an error if STAC items with the same ids are found in a collection.",
     )
     export_parser.add_argument(
-        "-c", "--collection",
+        "-c",
+        "--collection",
         type=str,
         help="Specific ID or regex pattern for which to filter matched collections from the catalog(s).",
     )
@@ -114,14 +115,17 @@ def run(ns: argparse.Namespace) -> int:
         elif ns.command == "update_collection":
             return update_api_collection(ns.mode, ns.stac_collection_uri, ns.exclude_summary) or 0
         else:
-            return export_catalog(
-                ns.directory,
-                ns.stac_host,
-                session,
-                ns.resume,
-                ns.ignore_duplicate_ids,
-                ns.collection,
-            ) or 0
+            return (
+                export_catalog(
+                    ns.directory,
+                    ns.stac_host,
+                    session,
+                    ns.resume,
+                    ns.ignore_duplicate_ids,
+                    ns.collection,
+                )
+                or 0
+            )
 
 
 def main(*args: str) -> int:

--- a/STACpopulator/export.py
+++ b/STACpopulator/export.py
@@ -167,7 +167,7 @@ def _export_catalog(
                 continue
             else:
                 raise DuplicateIDError(
-                    f"Duplicate collection ID {child.id} was already processed and were not allowed. "
+                    f"Duplicate collection ID {child.id} was already processed and was not allowed. "
                     f"Refine your search criteria or disable duplicate safeguard with the provided option."
                 )
         found_cols.add(child.id)

--- a/STACpopulator/export.py
+++ b/STACpopulator/export.py
@@ -124,12 +124,16 @@ def _export_catalog(
     start_time: int,
     resume: bool = False,
     ignore_duplicate_ids: bool = False,
+    collection_ignore_duplicate_ids: bool = False,
     collection_patterns: list[re.Pattern[str]] | None = None,
 ) -> None:
     """
     Export a STAC catalog or collection to files on disk.
 
     This is a recursive helper function initiated by the export_catalog function.
+
+    The collection patterns employ ``re.Pattern.match`` to allow both literal IDs and regexes.
+    Adjust the regex definitions as needed if you need a *search* over the entire IDs.
     """
     directory /= client.id
     file_name = "catalog.json" if isinstance(client, Client) else "collection.json"
@@ -145,6 +149,7 @@ def _export_catalog(
             resume,
             ignore_duplicate_ids,
         )
+    found_cols = set()
     for child in client.get_children():
         if (
             isinstance(child, pystac_client.CollectionClient)
@@ -156,9 +161,29 @@ def _export_catalog(
                 f"the collection patterns {json.dumps([col.pattern for col in collection_patterns])}."
             )
             continue
+        if found_cols & {child.id}:
+            if collection_ignore_duplicate_ids:
+                LOGGER.warning(
+                    f"Duplicate collection ID {child.id} was already processed. Skipping it."
+                )
+                continue
+            else:
+                raise DuplicateIDError(
+                    f"Duplicate collection ID {child.id} was already processed and were not allowed. "
+                    f"Refine your search criteria or disable duplicate safeguard with the provided option."
+                )
+        found_cols.add(child.id)
         child_type = "collection" if isinstance(child, pystac_client.CollectionClient) else "catalog"
         LOGGER.info(f"Exporting {child_type} [{child.id}]")
-        _export_catalog(child, directory, start_time, resume, ignore_duplicate_ids, collection_patterns)
+        _export_catalog(
+            child,
+            directory,
+            start_time,
+            resume,
+            ignore_duplicate_ids,
+            collection_ignore_duplicate_ids,
+            collection_patterns,
+        )
 
 
 def export_catalog(
@@ -167,6 +192,7 @@ def export_catalog(
     session: requests.Session,
     resume: bool = False,
     ignore_duplicate_ids: bool = False,
+    collection_ignore_duplicate_ids: bool = False,
     collections: Iterable[re.Pattern[str] | str] | None = None,
 ) -> None:
     """Export a STAC catalog to files on disk."""
@@ -178,6 +204,14 @@ def export_catalog(
     collection_patterns = []
     for col in collections if collections else []:
         if isinstance(col, str):  # convenience plain ID to regex
-            col = re.compile(f"^{col.strip('^$')}$")
+            col = re.compile(col)
         collection_patterns.append(col)
-    _export_catalog(client, directory, start_time, resume, ignore_duplicate_ids, collection_patterns)
+    _export_catalog(
+        client,
+        directory,
+        start_time,
+        resume,
+        ignore_duplicate_ids,
+        collection_ignore_duplicate_ids,
+        collection_patterns,
+    )

--- a/STACpopulator/export.py
+++ b/STACpopulator/export.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import time
 from typing import Iterable, cast
 
@@ -112,7 +113,7 @@ def _write_stac_data(
         elif not resume:
             raise FileExistsError(file)
     if create_parent:
-        file.parent.mkdir(exist_ok=True)
+        file.parent.mkdir(exist_ok=True, parents=True)
     with open(file, mode="w", encoding="utf-8") as f:
         json.dump(data, f)
 
@@ -123,6 +124,7 @@ def _export_catalog(
     start_time: int,
     resume: bool = False,
     ignore_duplicate_ids: bool = False,
+    collection_pattern: re.Pattern[str] | None = None,
 ) -> None:
     """
     Export a STAC catalog or collection to files on disk.
@@ -144,7 +146,15 @@ def _export_catalog(
             ignore_duplicate_ids,
         )
     for child in client.get_children():
-        _export_catalog(child, directory, start_time, resume, ignore_duplicate_ids)
+        if (
+            isinstance(child, pystac_client.CollectionClient) and
+            collection_pattern and not collection_pattern.match(child.id)
+        ):
+            LOGGER.info(f"Skipping collection {child.id} as it does not match the collection pattern")
+            continue
+        child_type = "collection" if isinstance(child, pystac_client.CollectionClient) else "catalog"
+        LOGGER.info(f"Exporting {child_type} [{child.id}]")
+        _export_catalog(child, directory, start_time, resume, ignore_duplicate_ids, collection_pattern)
 
 
 def export_catalog(
@@ -153,6 +163,7 @@ def export_catalog(
     session: requests.Session,
     resume: bool = False,
     ignore_duplicate_ids: bool = False,
+    collection: re.Pattern[str] | str | None = None,
 ) -> None:
     """Export a STAC catalog to files on disk."""
     stac_api_io = StacApiIO()
@@ -160,4 +171,7 @@ def export_catalog(
     directory = pathlib.Path(directory)
     client = Client.open(stac_host, stac_io=stac_api_io)
     start_time = time.time()
-    _export_catalog(client, directory, start_time, resume, ignore_duplicate_ids)
+    collection_pattern = collection
+    if isinstance(collection, str):  # convenience plain ID to regex
+        collection_pattern = re.compile(f"^{collection.strip('^$')}$")
+    _export_catalog(client, directory, start_time, resume, ignore_duplicate_ids, collection_pattern)

--- a/STACpopulator/export.py
+++ b/STACpopulator/export.py
@@ -163,9 +163,7 @@ def _export_catalog(
             continue
         if found_cols & {child.id}:
             if collection_ignore_duplicate_ids:
-                LOGGER.warning(
-                    f"Duplicate collection ID {child.id} was already processed. Skipping it."
-                )
+                LOGGER.warning(f"Duplicate collection ID {child.id} was already processed. Skipping it.")
                 continue
             else:
                 raise DuplicateIDError(

--- a/STACpopulator/export.py
+++ b/STACpopulator/export.py
@@ -124,7 +124,7 @@ def _export_catalog(
     start_time: int,
     resume: bool = False,
     ignore_duplicate_ids: bool = False,
-    collection_pattern: re.Pattern[str] | None = None,
+    collection_patterns: list[re.Pattern[str]] | None = None,
 ) -> None:
     """
     Export a STAC catalog or collection to files on disk.
@@ -148,17 +148,17 @@ def _export_catalog(
     for child in client.get_children():
         if (
             isinstance(child, pystac_client.CollectionClient)
-            and collection_pattern
-            and not collection_pattern.match(child.id)
+            and collection_patterns
+            and not any(col_pattern.match(child.id) for col_pattern in collection_patterns)
         ):
             LOGGER.info(
-                f"Skipping collection {child.id} as it does not match"
-                f"the collection pattern '{collection_pattern.pattern}'."
+                f"Skipping collection {child.id} as it does not match any of "
+                f"the collection patterns {json.dumps([col.pattern for col in collection_patterns])}."
             )
             continue
         child_type = "collection" if isinstance(child, pystac_client.CollectionClient) else "catalog"
         LOGGER.info(f"Exporting {child_type} [{child.id}]")
-        _export_catalog(child, directory, start_time, resume, ignore_duplicate_ids, collection_pattern)
+        _export_catalog(child, directory, start_time, resume, ignore_duplicate_ids, collection_patterns)
 
 
 def export_catalog(
@@ -167,7 +167,7 @@ def export_catalog(
     session: requests.Session,
     resume: bool = False,
     ignore_duplicate_ids: bool = False,
-    collection: re.Pattern[str] | str | None = None,
+    collections: Iterable[re.Pattern[str] | str] | None = None,
 ) -> None:
     """Export a STAC catalog to files on disk."""
     stac_api_io = StacApiIO()
@@ -175,7 +175,9 @@ def export_catalog(
     directory = pathlib.Path(directory)
     client = Client.open(stac_host, stac_io=stac_api_io)
     start_time = time.time()
-    collection_pattern = collection
-    if isinstance(collection, str):  # convenience plain ID to regex
-        collection_pattern = re.compile(f"^{collection.strip('^$')}$")
-    _export_catalog(client, directory, start_time, resume, ignore_duplicate_ids, collection_pattern)
+    collection_patterns = []
+    for col in collections if collections else []:
+        if isinstance(col, str):  # convenience plain ID to regex
+            col = re.compile(f"^{col.strip('^$')}$")
+        collection_patterns.append(col)
+    _export_catalog(client, directory, start_time, resume, ignore_duplicate_ids, collection_patterns)

--- a/STACpopulator/export.py
+++ b/STACpopulator/export.py
@@ -147,8 +147,9 @@ def _export_catalog(
         )
     for child in client.get_children():
         if (
-            isinstance(child, pystac_client.CollectionClient) and
-            collection_pattern and not collection_pattern.match(child.id)
+            isinstance(child, pystac_client.CollectionClient)
+            and collection_pattern
+            and not collection_pattern.match(child.id)
         ):
             LOGGER.info(f"Skipping collection {child.id} as it does not match the collection pattern")
             continue

--- a/STACpopulator/export.py
+++ b/STACpopulator/export.py
@@ -151,7 +151,10 @@ def _export_catalog(
             and collection_pattern
             and not collection_pattern.match(child.id)
         ):
-            LOGGER.info(f"Skipping collection {child.id} as it does not match the collection pattern")
+            LOGGER.info(
+                f"Skipping collection {child.id} as it does not match"
+                f"the collection pattern '{collection_pattern.pattern}'."
+            )
             continue
         child_type = "collection" if isinstance(child, pystac_client.CollectionClient) else "catalog"
         LOGGER.info(f"Exporting {child_type} [{child.id}]")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -139,9 +139,54 @@ def test_export_catalog_nested_no_duplicates(tmp_path, catalog_nested_info):
         export_catalog(tmp_path, url, session, ignore_duplicate_ids=False)
 
 
+@pytest.fixture
+def catalog_nested_info_without_duplicates():
+    """
+    Expected result for the export when ignoring duplicates.
+
+    Because the catalog ``usgs_galileo_catalog`` contains ``../usgs_galileo_controlled_images_catalog/catalog.json``
+    and `../usgs_galileo_controlled_images_catalog/catalog.json.1``, each refer to the same ID,
+    (i.e.: ``usgs_galileo_controlled_images_catalog``). At this nesting level, there is no distinction between
+    a "collection of catalog" and a "collection of items". They are just "directory" collections.
+    Therefore, although they have nested child items that differ, they get filtered preemptively by higher-level match.
+    Commented ones are the items and collections that happen to be under ``catalog.json.1``.
+    """
+    url = "https://asc-jupiter.s3.us-west-2.amazonaws.com/catalog.json"
+    file_structure = {
+        "usgs_jupiter_catalog",
+        "usgs_jupiter_catalog/catalog.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog",
+        "usgs_jupiter_catalog/usgs_europa_catalog/catalog.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/catalog.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/catalog.json",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/catalog.json.1",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_equi",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_equi/collection.json",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_equi/item-s0349875100.json",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_npola",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_npola/collection.json",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_npola/item-s0349875100.json",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_spola",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_spola/collection.json",
+        # "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_images_voy1_voy2_galileo_spola/item-s0360063900.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_equi",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_equi/collection.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_equi/item-10ESGLOBAL01.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_npola",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_npola/collection.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_npola/item-14ESGLOCOL01.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_spola",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_spola/collection.json",
+        "usgs_jupiter_catalog/usgs_europa_catalog/usgs_galileo_catalog/usgs_galileo_controlled_images_catalog/usgs_controlled_mosaics_voy1_voy2_galileo_spola/item-10ESGLOBAL01.json",
+    }
+    return url, file_structure
+
+
 @pytest.mark.vcr("test_export_catalog_nested.yaml")
-def test_export_catalog_nested_with_duplicates(tmp_path, catalog_nested_info):
-    url, expected = catalog_nested_info
+def test_export_catalog_nested_ignore_duplicates(tmp_path, catalog_nested_info_without_duplicates):
+    url, expected = catalog_nested_info_without_duplicates
     with (
         requests.Session() as session,
         pytest.warns((pystac_client.warnings.FallbackToPystac, pystac_client.warnings.NoConformsTo)),
@@ -149,29 +194,6 @@ def test_export_catalog_nested_with_duplicates(tmp_path, catalog_nested_info):
         export_catalog(tmp_path, url, session, ignore_duplicate_ids=True, collection_ignore_duplicate_ids=True)
     assert expected == {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
     _test_file_types(tmp_path)
-
-
-@pytest.mark.vcr("test_export_catalog_nested.yaml")
-def test_export_catalog_nested_with_many_duplicates(tmp_path, catalog_nested_info):
-    url, _ = catalog_nested_info
-    base_path = (
-        tmp_path
-        / "usgs_jupiter_catalog"
-        / "usgs_europa_catalog"
-        / "usgs_galileo_catalog"
-        / "usgs_galileo_controlled_images_catalog"
-    )
-    base_path.mkdir(parents=True)
-    for i in range(1, 20):
-        (base_path / f"catalog.json.{i}").touch()
-    with (
-        requests.Session() as session,
-        pytest.warns((pystac_client.warnings.FallbackToPystac, pystac_client.warnings.NoConformsTo)),
-    ):
-        export_catalog(
-            tmp_path, url, session, resume=True, ignore_duplicate_ids=True, collection_ignore_duplicate_ids=True
-        )
-    assert (base_path / "catalog.json.20").exists()
 
 
 @pytest.mark.vcr("test_export_api.yaml")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import pystac_client
 import pytest
@@ -145,7 +146,7 @@ def test_export_catalog_nested_with_duplicates(tmp_path, catalog_nested_info):
         requests.Session() as session,
         pytest.warns((pystac_client.warnings.FallbackToPystac, pystac_client.warnings.NoConformsTo)),
     ):
-        export_catalog(tmp_path, url, session, ignore_duplicate_ids=True)
+        export_catalog(tmp_path, url, session, ignore_duplicate_ids=True, collection_ignore_duplicate_ids=True)
     assert expected == {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
     _test_file_types(tmp_path)
 
@@ -167,5 +168,144 @@ def test_export_catalog_nested_with_many_duplicates(tmp_path, catalog_nested_inf
         requests.Session() as session,
         pytest.warns((pystac_client.warnings.FallbackToPystac, pystac_client.warnings.NoConformsTo)),
     ):
-        export_catalog(tmp_path, url, session, resume=True, ignore_duplicate_ids=True)
+        export_catalog(
+            tmp_path, url, session, resume=True, ignore_duplicate_ids=True, collection_ignore_duplicate_ids=True
+        )
     assert (base_path / "catalog.json.20").exists()
+
+
+@pytest.mark.vcr("test_export_api.yaml")
+def test_export_api_with_collection_filter_exact_match(tmp_path, catalog_api_info):
+    url, _ = catalog_api_info
+    expected_collections = {"EuroSAT-subset-train", "montreal_2023"}
+    expected_structure = {
+        "stac-fastapi",
+        "stac-fastapi/catalog.json",
+        "stac-fastapi/EuroSAT-subset-train",
+        "stac-fastapi/EuroSAT-subset-train/collection.json",
+        "stac-fastapi/EuroSAT-subset-train/item-EuroSAT-subset-train-sample-59-class-SeaLake.json",
+        "stac-fastapi/montreal_2023",
+        "stac-fastapi/montreal_2023/collection.json",
+        "stac-fastapi/montreal_2023/item-wildfire_timestamp_2023_08_30_12_00_00.json",
+    }
+    with requests.Session() as session:
+        export_catalog(tmp_path, url, session, collections=expected_collections)
+    result_structure = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+    assert result_structure == expected_structure
+    _test_file_types(tmp_path)
+
+
+@pytest.mark.vcr("test_export_api.yaml")
+def test_export_api_with_collection_filter_regex_pattern(tmp_path, catalog_api_info):
+    url, _ = catalog_api_info
+    pattern = re.compile(r"EuroSAT-subset-.*")
+    expected_structure = {
+        "stac-fastapi",
+        "stac-fastapi/catalog.json",
+        "stac-fastapi/EuroSAT-subset-train",
+        "stac-fastapi/EuroSAT-subset-train/collection.json",
+        "stac-fastapi/EuroSAT-subset-train/item-EuroSAT-subset-train-sample-59-class-SeaLake.json",
+        "stac-fastapi/EuroSAT-subset-validate",
+        "stac-fastapi/EuroSAT-subset-validate/collection.json",
+        "stac-fastapi/EuroSAT-subset-validate/item-EuroSAT-subset-validate-sample-19-class-SeaLake.json",
+        "stac-fastapi/EuroSAT-subset-test",
+        "stac-fastapi/EuroSAT-subset-test/collection.json",
+        "stac-fastapi/EuroSAT-subset-test/item-EuroSAT-subset-test-sample-19-class-SeaLake.json",
+    }
+    with requests.Session() as session:
+        export_catalog(tmp_path, url, session, collections=[pattern])
+    result_structure = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+    assert result_structure == expected_structure
+    _test_file_types(tmp_path)
+
+
+@pytest.mark.vcr("test_export_api.yaml")
+def test_export_api_with_collection_filter_mixed_patterns(tmp_path, catalog_api_info):
+    url, _ = catalog_api_info
+    patterns = [
+        re.compile(r"EuroSAT-full-.*"),
+        "newyork_2024",
+    ]
+    expected_structure = {
+        "stac-fastapi",
+        "stac-fastapi/catalog.json",
+        "stac-fastapi/EuroSAT-full-train",
+        "stac-fastapi/EuroSAT-full-train/collection.json",
+        "stac-fastapi/EuroSAT-full-train/item-EuroSAT-full-train-sample-16199-class-SeaLake.json",
+        "stac-fastapi/EuroSAT-full-test",
+        "stac-fastapi/EuroSAT-full-test/collection.json",
+        "stac-fastapi/EuroSAT-full-test/item-EuroSAT-full-test-sample-5399-class-SeaLake.json",
+        "stac-fastapi/EuroSAT-full-validate",
+        "stac-fastapi/EuroSAT-full-validate/collection.json",
+        "stac-fastapi/EuroSAT-full-validate/item-EuroSAT-full-validate-sample-5399-class-SeaLake.json",
+        "stac-fastapi/newyork_2024",
+        "stac-fastapi/newyork_2024/collection.json",
+        "stac-fastapi/newyork_2024/item-wildfire_timestamp_2024_06_30_12_00_00.json",
+    }
+    with requests.Session() as session:
+        export_catalog(tmp_path, url, session, collections=patterns)
+    result_structure = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+    assert result_structure == expected_structure
+    _test_file_types(tmp_path)
+
+
+@pytest.mark.vcr("test_export_api.yaml")
+def test_export_api_with_collection_filter_partial_match_regex(tmp_path, catalog_api_info):
+    url, _ = catalog_api_info
+    pattern = re.compile(r".*_202[34]")
+    expected_structure = {
+        "stac-fastapi",
+        "stac-fastapi/catalog.json",
+        "stac-fastapi/montreal_2023",
+        "stac-fastapi/montreal_2023/collection.json",
+        "stac-fastapi/montreal_2023/item-wildfire_timestamp_2023_08_30_12_00_00.json",
+        "stac-fastapi/newyork_2024",
+        "stac-fastapi/newyork_2024/collection.json",
+        "stac-fastapi/newyork_2024/item-wildfire_timestamp_2024_06_30_12_00_00.json",
+    }
+    with requests.Session() as session:
+        export_catalog(tmp_path, url, session, collections=[pattern])
+    result_structure = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+    assert result_structure == expected_structure
+    _test_file_types(tmp_path)
+
+
+@pytest.mark.vcr("test_export_api.yaml")
+def test_export_api_with_collection_filter_no_match(tmp_path, catalog_api_info):
+    url, _ = catalog_api_info
+    pattern = re.compile(r"NonExistentCollection-.*")
+    expected_structure = {
+        "stac-fastapi",
+        "stac-fastapi/catalog.json",
+    }
+    with requests.Session() as session:
+        export_catalog(tmp_path, url, session, collections=[pattern])
+    result_structure = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+    assert result_structure == expected_structure
+
+
+@pytest.mark.vcr("test_export_api.yaml")
+def test_export_api_with_collection_filter_complex_regex(tmp_path, catalog_api_info):
+    url, _ = catalog_api_info
+    pattern = re.compile(r"EuroSAT-(subset|full)-(train|validate)")
+    expected_structure = {
+        "stac-fastapi",
+        "stac-fastapi/catalog.json",
+        "stac-fastapi/EuroSAT-subset-train",
+        "stac-fastapi/EuroSAT-subset-train/collection.json",
+        "stac-fastapi/EuroSAT-subset-train/item-EuroSAT-subset-train-sample-59-class-SeaLake.json",
+        "stac-fastapi/EuroSAT-subset-validate",
+        "stac-fastapi/EuroSAT-subset-validate/collection.json",
+        "stac-fastapi/EuroSAT-subset-validate/item-EuroSAT-subset-validate-sample-19-class-SeaLake.json",
+        "stac-fastapi/EuroSAT-full-train",
+        "stac-fastapi/EuroSAT-full-train/collection.json",
+        "stac-fastapi/EuroSAT-full-train/item-EuroSAT-full-train-sample-16199-class-SeaLake.json",
+        "stac-fastapi/EuroSAT-full-validate",
+        "stac-fastapi/EuroSAT-full-validate/collection.json",
+        "stac-fastapi/EuroSAT-full-validate/item-EuroSAT-full-validate-sample-5399-class-SeaLake.json",
+    }
+    with requests.Session() as session:
+        export_catalog(tmp_path, url, session, collections=[pattern])
+    result_structure = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+    assert result_structure == expected_structure
+    _test_file_types(tmp_path)


### PR DESCRIPTION
- Allows specifying a collection ID or regex to limit how many collections and their items are extracted from a possibly large catalog. 
- Add explicit log entries of processed or skipped Catalogs/Collections (fixes #101).
- Fix `export` target directory parent(s) creation if missing.
