### PR TITLE
fix interaction between pre-commit hooks and bump-my-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.env
 .venv/
 jupyter/
+venv/
 
 ## Tests
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     rev: v0.48.0
     hooks:
       - id: markdownlint
-        args: [--fix, --config, pyproject.toml, --configPointer, /tool/markdownlint, "**/*.md"]
+        args: [--fix, --config, pyproject.toml, --configPointer, /tool/markdownlint, "--ignore-path", ".gitignore", "**/*.md"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/crim-ca/stac-populator) (latest)
 
-* fix interaction between pre-commit hooks and bump-my-version.
+* Fix interaction between pre-commit hooks and bump-my-version.
 
 ## [0.15.0](https://github.com/crim-ca/stac-populator/tree/0.15.0) (2026-04-21)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,9 @@
 
 ## [Unreleased](https://github.com/crim-ca/stac-populator) (latest)
 
-<!-- insert list items of new changes here -->
+* fix interaction between pre-commit hooks and bump-my-version.
 
 ## [0.15.0](https://github.com/crim-ca/stac-populator/tree/0.15.0) (2026-04-21)
-
 
 * Add `-c`/`--collection` option to `export` operation to filter which collections should be exported,
   rather than the entire catalog. The value can be the plain Collection ID or a regex pattern.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ MD033.allowed_elements = ["br"]
 
 [project]
 name = "STACpopulator"
-version = "1.15.1"
+version = "0.15.0"
 description = "Utility to populate STAC Catalog, Collections and Items from various dataset/catalog sources."
 requires-python = ">=3.10,<4"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,13 +85,16 @@ replace = "LABEL version=\"{new_version}\""
 
 [[tool.bumpversion.files]]
 filename = "CHANGES.md"
-search = "## [Unreleased](https://github.com/crim-ca/stac-populator) (latest)"
+search = """
+## [Unreleased](https://github.com/crim-ca/stac-populator) (latest)
+"""
 replace = """
 ## [Unreleased](https://github.com/crim-ca/stac-populator) (latest)
 
 <!-- insert list items of new changes here -->
 
-## [{new_version}](https://github.com/crim-ca/stac-populator/tree/{new_version}) ({now:%Y-%m-%d})"""
+## [{new_version}](https://github.com/crim-ca/stac-populator/tree/{new_version}) ({now:%Y-%m-%d})
+"""
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
@@ -129,7 +132,7 @@ MD033.allowed_elements = ["br"]
 
 [project]
 name = "STACpopulator"
-version = "0.15.0"
+version = "1.15.1"
 description = "Utility to populate STAC Catalog, Collections and Items from various dataset/catalog sources."
 requires-python = ">=3.10,<4"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,7 @@ replace = """
 
 <!-- insert list items of new changes here -->
 
-## [{new_version}](https://github.com/crim-ca/stac-populator/tree/{new_version}) ({now:%Y-%m-%d})
-"""
+## [{new_version}](https://github.com/crim-ca/stac-populator/tree/{new_version}) ({now:%Y-%m-%d})"""
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"


### PR DESCRIPTION
When bump-my-version runs and creates a new version it adds an additional newline to the CHANGES.md file. This line is then flagged by markdownlint when then pre-commit hooks run and the commit should be blocked.

However, since version bump commits are sometimes pushed directly to master instead of through a PR then these checks don't run. This means that the next PR **after** the version has been updated will fail the pre-commit checks. 

For example, see #144 which was the first commit after https://github.com/crim-ca/stac-populator/commit/c5a02c7568968bd5af2cfc94d1e027cc458e7c62 was pushed to master. This caused this action to fail (https://github.com/crim-ca/stac-populator/actions/runs/24754811983/job/72425655164)

In order to fix this, this PR updates the bump-my-version configuration in pyproject.toml in order to not include the newline. This temporarily fixes the issue but the better solution would be to ensure that the checks run by github actions run every time there is a change to this repo. In order to do this we should disable the ability to push directly to master. This means that every change has to go through a PR, including version bumps. This will ensure that all changes are flagged if an action fails.
I don't have permission to do this so could @fmigneault (or someone else with permission) please update that when you can.

Some additional changes made in this PR in order to update the pre-commit hooks as well:

- added the `--ignore-path` flag to markdownlint so that it doesn't try to fix non-project files
- added `venv/` to the .gitignore file since that is a common name for a virtual environment (and so that markdownlint now ignores it as expected) 